### PR TITLE
Add template feature

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -134,8 +134,9 @@ module.exports = function(config) {
       preserveSymlinks: true,
       plugins: [
         alias({
-          'sinuous/observable': __dirname + '/packages/sinuous/observable/src/index.js',
           'sinuous/h': __dirname + '/packages/sinuous/h/src/index.js',
+          'sinuous/observable': __dirname + '/packages/sinuous/observable/src/observable.js',
+          'sinuous/template': __dirname + '/packages/sinuous/template/src/template.js',
           'sinuous/map': __dirname + '/packages/sinuous/map/src/map.js',
           'sinuous': __dirname + '/packages/sinuous/src/index.js',
           'tape': __dirname + '/scripts/tape/dist.js'

--- a/packages/sinuous/.eslintrc.yml
+++ b/packages/sinuous/.eslintrc.yml
@@ -9,6 +9,7 @@ settings:
 
 rules:
   no-var: off
+  no-cond-assign: off
   no-negated-condition: error
   # fp/no-arguments: error
   fp/no-class: error

--- a/packages/sinuous/h/src/insert.js
+++ b/packages/sinuous/h/src/insert.js
@@ -1,16 +1,6 @@
 import { clearAll, normalizeIncomingArray } from './utils.js';
 
-export function insert(subscribe, parent, accessor, current, marker) {
-  if (typeof accessor !== 'function') {
-    return insertExpression(subscribe, parent, accessor, current, marker);
-  }
-
-  subscribe(function() {
-    current = insertExpression(subscribe, parent, accessor(), current, marker);
-  });
-}
-
-export function insertExpression(subscribe, parent, value, current, marker) {
+export function insert(subscribe, parent, value, marker, current) {
   if (value === current) return current;
   parent = (marker && marker.parentNode) || parent;
   const t = typeof value;
@@ -40,7 +30,7 @@ export function insertExpression(subscribe, parent, value, current, marker) {
     current = clearAll(parent, current, marker);
   } else if (t === 'function') {
     subscribe(function() {
-      current = insertExpression(subscribe, parent, value(), current, marker);
+      current = insert(subscribe, parent, value(), marker, current);
     });
   } else if (value instanceof Node) {
     if (Array.isArray(current)) {

--- a/packages/sinuous/h/test/insert-markers.js
+++ b/packages/sinuous/h/test/insert-markers.js
@@ -9,7 +9,7 @@ h.insert = h.insert.bind(h, subscribe);
 
 function insert(val) {
   const parent = clone(container);
-  h.insert(parent, val, undefined, parent.childNodes[1]);
+  h.insert(parent, val, parent.childNodes[1]);
   return parent;
 }
 
@@ -136,28 +136,28 @@ test('can insert a changing array of nodes', t => {
   div2.textContent = '2';
   span3.textContent = '3';
 
-  current = h.insert(container, [], current, marker);
+  current = h.insert(container, [], marker, current);
   t.equal(container.innerHTML, '');
 
-  current = h.insert(container, [span1, div2, span3], current, marker);
+  current = h.insert(container, [span1, div2, span3], marker, current);
   t.equal(container.innerHTML, '<span>1</span><div>2</div><span>3</span>');
 
-  current = h.insert(container, [div2, span3], current, marker);
+  current = h.insert(container, [div2, span3], marker, current);
   t.equal(container.innerHTML, '<div>2</div><span>3</span>');
 
-  current = h.insert(container, [div2, span3], current, marker);
+  current = h.insert(container, [div2, span3], marker, current);
   t.equal(container.innerHTML, '<div>2</div><span>3</span>');
 
-  current = h.insert(container, [span3, div2], current, marker);
+  current = h.insert(container, [span3, div2], marker, current);
   t.equal(container.innerHTML, '<span>3</span><div>2</div>');
 
-  current = h.insert(container, [], current, marker);
+  current = h.insert(container, [], marker, current);
   t.equal(container.innerHTML, '');
 
-  current = h.insert(container, [span3], current, marker);
+  current = h.insert(container, [span3], marker, current);
   t.equal(container.innerHTML, '<span>3</span>');
 
-  current = h.insert(container, [div2], current, marker);
+  current = h.insert(container, [div2], marker, current);
   t.equal(container.innerHTML, '<div>2</div>');
   t.end();
 });

--- a/packages/sinuous/h/test/insert.js
+++ b/packages/sinuous/h/test/insert.js
@@ -175,9 +175,9 @@ test('can insert a changing array of nodes', t => {
   test([n4, n3, n2, n1]);
 
   function test(array) {
-    current = h.insert(parent, array, current);
+    current = h.insert(parent, array, undefined, current);
     t.equal(parent.innerHTML, expected(array));
-    current = h.insert(parent, orig, current);
+    current = h.insert(parent, orig, undefined, current);
     t.equal(parent.innerHTML, origExpected);
   }
 

--- a/packages/sinuous/map/src/map.js
+++ b/packages/sinuous/map/src/map.js
@@ -105,11 +105,14 @@ export function reconcile(
 
   // Fast path for clear
   if (length === 0) {
-    if (beforeNode || afterNode) {
+    if (beforeNode || (afterNode && afterNode !== parent.lastChild)) {
       let node = beforeNode ? beforeNode.nextSibling : parent.firstChild;
       removeNodes(parent, node, afterNode ? afterNode : null);
     } else {
       parent.textContent = '';
+      if (afterNode) {
+        parent.appendChild(afterNode);
+      }
     }
 
     disposer._disposeAll();

--- a/packages/sinuous/map/src/map.js
+++ b/packages/sinuous/map/src/map.js
@@ -19,11 +19,11 @@ export default function map(items, expr) {
     const beforeNode = afterNode ? afterNode.previousSibling : null;
     let useFragment = !parent && !afterNode;
 
-    function createFn(parent, item, i, afterNode) {
+    function createFn(parent, item, i, data, afterNode) {
       return root(disposeFn => {
         const node = addNode(
           parent,
-          expr(item, i),
+          expr(item, i, data),
           afterNode,
           ++groupCounter
         );
@@ -122,7 +122,7 @@ export function reconcile(
   // Fast path for create
   if (renderedValues.length === 0) {
     for (let i = 0; i < length; i++) {
-      createFn(parent, data[i], i, afterNode);
+      createFn(parent, data[i], i, data, afterNode);
     }
     after();
     return data.slice();
@@ -224,7 +224,7 @@ export function reconcile(
   if (prevEnd < prevStart) {
     if (newStart <= newEnd) {
       while (newStart <= newEnd) {
-        createFn(parent, data[newStart], newStart, newAfterNode);
+        createFn(parent, data[newStart], newStart, data, newAfterNode);
         newStart++;
       }
     }
@@ -268,7 +268,7 @@ export function reconcile(
     !doRemove && (parent.textContent = '');
 
     for (let i = newStart; i <= newEnd; i++) {
-      createFn(parent, data[i], i, newAfterNode);
+      createFn(parent, data[i], i, data, newAfterNode);
     }
     after();
     return data.slice();
@@ -300,7 +300,7 @@ export function reconcile(
       lisIdx--;
     } else {
       if (P[i] === -1) {
-        tmpD = createFn(parent, data[i], i, newAfterNode);
+        tmpD = createFn(parent, data[i], i, data, newAfterNode);
       } else {
         tmpD = nodes[P[i]];
         insertNodes(parent, tmpD, step(tmpD, FORWARD), newAfterNode);

--- a/packages/sinuous/observable/src/index.js
+++ b/packages/sinuous/observable/src/index.js
@@ -1,2 +1,0 @@
-export * from './observable.js';
-export { default } from './observable.js';

--- a/packages/sinuous/package.json
+++ b/packages/sinuous/package.json
@@ -15,7 +15,10 @@
     "observable/package.json",
     "map/dist",
     "map/src",
-    "map/package.json"
+    "map/package.json",
+    "template/dist",
+    "template/src",
+    "template/package.json"
   ],
   "peerDependencies": {
     "sinuous": ">=0.6.0"

--- a/packages/sinuous/src/index.js
+++ b/packages/sinuous/src/index.js
@@ -3,7 +3,6 @@ import { context } from 'sinuous/h';
 import observable, * as api from 'sinuous/observable';
 
 export const h = context(api);
-
 export default context;
 export {
   observable,

--- a/packages/sinuous/template/README.md
+++ b/packages/sinuous/template/README.md
@@ -1,0 +1,6 @@
+# 🐍 Sinuous Template
+
+![Badge size](http://img.badgesize.io/https://unpkg.com/sinuous@latest/template/dist/template.js?compression=gzip&label=gzip&style=flat-square)
+[![codecov](https://img.shields.io/codecov/c/github/luwes/sinuous/template.svg?style=flat-square)](https://codecov.io/gh/luwes/sinuous)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+

--- a/packages/sinuous/template/package.json
+++ b/packages/sinuous/template/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sinuous-template",
+  "private": true,
+  "version": "0.0.1",
+  "description": "Sinuous template",
+  "module": "dist/template.mjs",
+  "main": "dist/template.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "lint": "eslint src",
+    "prepublishOnly": "yarn lint && (cd ../../.. && yarn build)"
+  }
+}

--- a/packages/sinuous/template/src/constants.js
+++ b/packages/sinuous/template/src/constants.js
@@ -1,0 +1,1 @@
+export const EMPTY_ARR = [];

--- a/packages/sinuous/template/src/template.js
+++ b/packages/sinuous/template/src/template.js
@@ -12,7 +12,7 @@ export function t(key) {
   return tag;
 }
 
-export function s(key) {
+export function o(key) {
   const observedTag = t(key);
   observedTag._observable = 1;
   return observedTag;

--- a/packages/sinuous/template/src/template.js
+++ b/packages/sinuous/template/src/template.js
@@ -1,0 +1,85 @@
+import { EMPTY_ARR } from './constants.js';
+
+let actions;
+
+export function t(key) {
+  const tag = () => key;
+  tag.$ = (el, action) => {
+    action._tag = tag;
+    action._el = el;
+    actions.push(action);
+  };
+  return tag;
+}
+
+export function s(key) {
+  const observedTag = t(key);
+  observedTag._observable = 1;
+  return observedTag;
+}
+
+export function template(fn) {
+  actions = [];
+
+  const fragment = document.createDocumentFragment();
+  fragment.appendChild(fn());
+
+  actions.forEach((action) => {
+    action._paths = [];
+    let el = action._el;
+    let parent;
+    while (parent = el.parentNode) {
+      action._paths.unshift(EMPTY_ARR.indexOf.call(parent.children, el));
+      el = parent;
+    }
+  });
+
+  const cloneActions = actions;
+  actions = null;
+
+  return function clone(data) {
+    const el = fragment.cloneNode(true);
+    el.firstChild.data = data;
+
+    for (let i = 0; i < cloneActions.length; i++) {
+      const action = cloneActions[i];
+      const paths = action._paths;
+
+      let target = el;
+      let j = 0;
+      while (j < paths.length) {
+        target = target.firstChild;
+        const path = paths[j];
+        let k = 0;
+        while (k < path) {
+          target = target.nextSibling;
+          k += 1;
+        }
+        j += 1;
+      }
+
+      const tag = action._tag;
+      const key = tag();
+      const value = data[key];
+      if (value != null) {
+        action(target, value);
+      }
+
+      if (tag._observable) {
+        observeProperty(data, key, value, action, target);
+      }
+    }
+
+    return el;
+  };
+}
+
+function observeProperty(data, key, value, action, target) {
+  Object.defineProperty(data, key, {
+    get() { return value; },
+    set(newValue) {
+      value = newValue;
+      action(target, newValue);
+    }
+  });
+}

--- a/packages/sinuous/template/test/.eslintrc.yml
+++ b/packages/sinuous/template/test/.eslintrc.yml
@@ -1,0 +1,9 @@
+---
+env:
+  mocha: true
+
+globals:
+  assert: false
+  should: false
+  expect: false
+  sinon: false

--- a/scripts/bundles.js
+++ b/scripts/bundles.js
@@ -10,11 +10,11 @@ export const bundleFormats = {
 
 export const bundles = [
   {
+    external: ['sinuous'],
     formats: [ESM, UMD],
-    external: ['sinuous/observable'],
-    global: 'sinuous',
-    name: 'sinuous',
-    input: 'packages/sinuous/src/index.js'
+    global: 'observable',
+    name: 'observable',
+    input: 'packages/sinuous/observable/src/observable.js'
   },
   {
     external: ['sinuous'],
@@ -26,9 +26,9 @@ export const bundles = [
   {
     external: ['sinuous'],
     formats: [ESM, UMD],
-    global: 'observable',
-    name: 'observable',
-    input: 'packages/sinuous/observable/src/index.js'
+    global: 'template',
+    name: 'template',
+    input: 'packages/sinuous/template/src/template.js'
   },
   {
     external: ['sinuous'],
@@ -36,6 +36,13 @@ export const bundles = [
     global: 'map',
     name: 'map',
     input: 'packages/sinuous/map/src/map.js'
+  },
+  {
+    external: ['sinuous/observable'],
+    formats: [ESM, UMD],
+    global: 'sinuous',
+    name: 'sinuous',
+    input: 'packages/sinuous/src/index.js'
   }
 ];
 

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -95,7 +95,8 @@ function getConfig(options) {
             props: {
               cname: 6,
               props: {
-                // $_listeners: '__l',
+                // $_tag: '__t',
+                // $_observable: '__o',
                 // $_observables: '__o',
                 // $_children: '__c',
                 // $_update: '__u'


### PR DESCRIPTION
This change adds an opt-in `template` feature which can be used for apps that have repeated html blocks. The performance gains come from using the native `element.cloneNode()` method.

A template can look something like this:

```js
	const Row = template(() => html`
		<tr class=${ o('selected') }>
			<td class=col-md-1 textContent=${ t('id') } />
			<td class=col-md-4><a>${ o('label') }</a></td>
			<td class=col-md-1><a>
				<span class="glyphicon glyphicon-remove remove" />
			</a></td>
			<td class=col-md-6 />
		</tr>
	`);
```

- `o` is an observable tag
it sets a proxy on the passed object property and repeats the recorded tag action.
- `t` is a normal tag.

The `Row` in this case would accept a object like so

```js
	Row({ id: 1, label: 'Banana', selected: 'peel' });
```

Performance is looking super on my local machine.

<img width="415" alt="Screen Shot 2019-06-12 at 9 01 25 AM" src="https://user-images.githubusercontent.com/360826/59368042-37f09a00-8cf2-11e9-903d-6abbef568a0d.png">
