### PR TITLE
Add transaction method

### DIFF
--- a/packages/sinuous/observable/src/observable.js
+++ b/packages/sinuous/observable/src/observable.js
@@ -94,8 +94,10 @@ function observable(value) {
     }
 
     if (queue) {
+      if (data._pending === undefined) {
+        queue.push(data);
+      }
       data._pending = nextValue;
-      queue.push(data);
       return nextValue;
     }
 

--- a/packages/sinuous/observable/src/observable.js
+++ b/packages/sinuous/observable/src/observable.js
@@ -1,4 +1,5 @@
 let currentUpdate;
+let queue;
 
 /**
  * Returns true if there is an active listener.
@@ -47,6 +48,27 @@ export function sample(fn) {
 }
 
 /**
+ * Creates a transation where in an observable can be set multiple times but
+ * only trigger a computation once.
+ * @param  {Function} fn
+ * @return {*}
+ */
+export function transaction(fn) {
+  queue = [];
+  const result = fn();
+  let q = queue;
+  queue = undefined;
+  q.forEach((data) => {
+    if (data._pending) {
+      const pending = data._pending;
+      data._pending = undefined;
+      data(pending);
+    }
+  });
+  return result;
+}
+
+/**
  * Creates a new observable, returns a function which can be used to get
  * the observable's value by calling the function without any arguments
  * and set the value by passing one argument of any type.
@@ -71,11 +93,17 @@ function observable(value) {
       return value;
     }
 
+    if (queue) {
+      data._pending = nextValue;
+      queue.push(data);
+      return nextValue;
+    }
+
     value = nextValue;
 
     // Clear `currentUpdate` otherwise a computed triggered by a set
     // in another computed is seen as a child of that other computed.
-    const update = currentUpdate;
+    const clearedUpdate = currentUpdate;
     currentUpdate = undefined;
 
     data._listeners.forEach(update => (update._fresh = 0));
@@ -84,7 +112,7 @@ function observable(value) {
       if (!update._fresh) update();
     });
 
-    currentUpdate = update;
+    currentUpdate = clearedUpdate;
     return value;
   }
 

--- a/packages/sinuous/observable/test/transaction.js
+++ b/packages/sinuous/observable/test/transaction.js
@@ -1,0 +1,29 @@
+import test from 'tape';
+import { o, S, root, transaction } from '../src/observable.js';
+
+test("batches changes until end", function (t) {
+  var d = o(1);
+
+  transaction(function () {
+    d(2);
+    t.equal(d(), 1);
+  });
+
+  t.equal(d(), 2);
+  t.end();
+});
+
+test("halts propagation within its scope", function (t) {
+  root(function () {
+    var d = o(1);
+    var f = S(function() { return d(); });
+
+    transaction(function () {
+      d(2);
+      t.equal(f(), 1);
+    });
+
+    t.equal(f(), 2);
+    t.end();
+  });
+});

--- a/packages/sinuous/test/test.js
+++ b/packages/sinuous/test/test.js
@@ -10,6 +10,7 @@ import '../observable/test/S.js';
 import '../observable/test/sample.js';
 import '../observable/test/root.js';
 import '../observable/test/dispose.js';
+import '../observable/test/transaction.js';
 import '../map/test/add-node.js';
 import '../map/test/map.js';
 import '../map/test/map-basic.js';


### PR DESCRIPTION
This adds a minimal way for batching observable sets.

Related issue #21