### PR TITLE
Add `hydrate` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.15.0 - 2019-09-13
+
+### Added
+
+- Added basic `hydrate` feature [#36](https://github.com/luwes/sinuous/pull/36)
+
 ## 0.14.2 - 2019-09-04
 
 ### Fixed

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -141,6 +141,7 @@ module.exports = function(config) {
           'sinuous/htm': __dirname + '/packages/sinuous/htm/src/index.js',
           'sinuous/observable': __dirname + '/packages/sinuous/observable/src/observable.js',
           'sinuous/template': __dirname + '/packages/sinuous/template/src/template.js',
+          'sinuous/hydrate': __dirname + '/packages/sinuous/hydrate/src/index.js',
           'sinuous/map': __dirname + '/packages/sinuous/map/src/index.js',
           'sinuous': __dirname + '/packages/sinuous/src/index.js',
           'tape': __dirname + '/scripts/tape/dist.js'

--- a/packages/sinuous/h/src/h.js
+++ b/packages/sinuous/h/src/h.js
@@ -42,7 +42,6 @@ export function context(options, isSvg) {
         }
       } else if (type === 'object') {
         for (let name in arg) {
-          // Create scope for every entry.
           property(name, arg[name], el, isSvg);
         }
       } else if (type === 'function') {
@@ -56,20 +55,21 @@ export function context(options, isSvg) {
           }
         } else {
           // Support Components
-          el = arg.apply(null, args.splice(0));
+          el = arg.apply(null, args.splice(1));
         }
       } else {
         el.appendChild(document.createTextNode('' + arg));
       }
     }
 
-    while (args.length) {
-      item(args.shift());
-    }
+    args.forEach(item);
     return el;
   }
 
+  api.insert = insert;
+  api.property = property;
   api.h = h;
+
   return h;
 }
 

--- a/packages/sinuous/h/src/insert.js
+++ b/packages/sinuous/h/src/insert.js
@@ -4,14 +4,14 @@ import { clearAll } from './utils.js';
 
 let groupCounter = 0;
 
-export function insert(parent, value, marker, current) {
+export function insert(parent, value, marker, current, startNode) {
   // This is needed if the parent is a DocumentFragment initially.
   parent = (marker && marker.parentNode) || parent;
 
   const t = typeof value;
   if (value === current);
   else if ((!value && value !== 0) || value === true) {
-    clearAll(parent, current, marker);
+    clearAll(parent, current, marker, startNode);
     current = null;
   } else if (
     (!current || typeof current === 'string') &&
@@ -34,11 +34,11 @@ export function insert(parent, value, marker, current) {
     current = value;
   } else if (t === 'function') {
     api.subscribe(function() {
-      current = insert(parent, value(), marker, current);
+      current = api.insert(parent, value(), marker, current);
     });
   } else {
     // Block for nodes, fragments, Arrays, non-stringables and node -> stringable.
-    clearAll(parent, current, marker);
+    clearAll(parent, current, marker, startNode);
 
     if (!(value instanceof Node)) {
       // Passing an empty array creates a DocumentFragment.

--- a/packages/sinuous/hydrate/.eslintrc.yml
+++ b/packages/sinuous/hydrate/.eslintrc.yml
@@ -1,0 +1,3 @@
+rules:
+  jsdoc/check-indentation: off
+  jsdoc/require-description-complete-sentence: off

--- a/packages/sinuous/hydrate/README.md
+++ b/packages/sinuous/hydrate/README.md
@@ -1,0 +1,6 @@
+# Sinuous Hydrate
+
+![Badge size](http://img.badgesize.io/https://unpkg.com/sinuous@latest/hydrate/dist/hydrate.min.js?compression=gzip&label=gzip&style=flat-square)
+[![codecov](https://img.shields.io/codecov/c/github/luwes/sinuous/hydrate.svg?style=flat-square)](https://codecov.io/gh/luwes/sinuous)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+

--- a/packages/sinuous/hydrate/package.json
+++ b/packages/sinuous/hydrate/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sinuous-hydrate",
+  "private": true,
+  "version": "0.0.1",
+  "description": "Sinuous hydrate",
+  "module": "../module/hydrate.js",
+  "main": "../dist/hydrate.js",
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "lint": "eslint src",
+    "prepublishOnly": "yarn lint && (cd ../../.. && yarn build)"
+  }
+}

--- a/packages/sinuous/hydrate/src/hydrate.js
+++ b/packages/sinuous/hydrate/src/hydrate.js
@@ -1,0 +1,156 @@
+import { h, hs, api } from 'sinuous';
+
+export const EMPTY_ARR = [];
+export const _ = {};
+
+let isHydrated;
+
+/**
+ * Create a sinuous `treeify` function.
+ * @param  {boolean} isSvg
+ * @return {Function}
+ */
+export function context(isSvg) {
+  function treeify() {
+    if (isHydrated) {
+      // Hydrate on first pass, create on the rest.
+      return (isSvg ? hs : h).apply(null, arguments);
+    }
+
+    const args = EMPTY_ARR.slice.call(arguments);
+    const tree = {
+      _children: []
+    };
+
+    function item(arg) {
+      if (isSvg) tree._isSvg = isSvg;
+      if (arg == null);
+      else if (arg === _) {
+        tree._children.push(arg);
+      } else if (typeof arg === 'string') {
+        if (tree._tag) {
+          tree._children.push(arg);
+        } else {
+          tree._tag = arg;
+        }
+      } else if (Array.isArray(arg)) {
+        arg.forEach(item);
+      } else if (typeof arg === 'object') {
+        if (arg._tag) {
+          tree._children.push(arg);
+        } else {
+          tree._props = arg;
+        }
+      } else if (typeof arg === 'function') {
+        tree._children.push(arg);
+      }
+    }
+
+    args.forEach(item);
+
+    return tree._tag
+      ? tree
+      : tree._children[1]
+      ? tree._children
+      : tree._children[0];
+  }
+
+  return treeify;
+}
+
+/**
+ * Hydrates the root node with a passed delta tree structure.
+ *
+ * `delta` looks like:
+ * {
+ *   _tag: 'div',
+ *   _props: { class: '' },
+ *   _children: []
+ * }
+ *
+ * @param  {object} delta
+ * @param  {Node} root
+ * @return {Node} Returns the `root`.
+ */
+export function hydrate(delta, root) {
+  const children = Array.isArray(delta) ? delta : delta._children;
+  const args = [root, delta._props, children];
+  const isSvg = delta._isSvg;
+  let el;
+  let childNodes;
+
+  function item(arg) {
+    if (arg instanceof Node) {
+      el = arg;
+      // Keep a child pointer for multiple hydrate calls per element.
+      el._index = el._index || 0;
+      // Make a copy of the current child tree.
+      childNodes = EMPTY_ARR.slice.call(el.childNodes);
+    } else if (Array.isArray(arg)) {
+      arg.forEach(item);
+    } else if (el) {
+      let target = getChildNode(childNodes, el._index);
+      if (target) {
+        if (arg === _) {
+          el._index++;
+        } else if (typeof arg === 'string') {
+          if (target.data !== arg) target.data = arg;
+          el._index++;
+        } else if (typeof arg === 'object') {
+          if (arg._children) {
+            hydrate(arg, target);
+            el._index++;
+          } else {
+            for (let name in arg) {
+              api.property(name, arg[name], el, isSvg);
+            }
+          }
+        } else if (typeof arg === 'function') {
+          let hydrated;
+          let current = target.data;
+          let marker;
+          let startNode;
+          api.subscribe(function() {
+            isHydrated = hydrated;
+
+            let result = arg();
+            if (hydrated) {
+              current = api.insert(el, result, marker, current, startNode);
+            } else {
+              if (typeof result === 'string' || typeof result === 'number') {
+                el._index++;
+              } else {
+                if (Array.isArray(result)) {
+                  startNode = target;
+                  target = el;
+                }
+                hydrate(result, target);
+                current = [];
+              }
+
+              marker = el.insertBefore(
+                document.createTextNode(''),
+                getChildNode(childNodes, el._index)
+              );
+            }
+
+            isHydrated = false;
+            hydrated = true;
+          });
+        }
+      } else {
+        // Adjecent text cannot be walked, fallback to creation.
+        (isSvg ? hs : h)(el, arg);
+      }
+    }
+  }
+
+  args.forEach(item);
+
+  return el;
+}
+
+function getChildNode(childNodes, index) {
+  return childNodes
+    .filter(child => child.nodeType !== 3 || child.data.trim())[index];
+}

--- a/packages/sinuous/hydrate/src/index.js
+++ b/packages/sinuous/hydrate/src/index.js
@@ -1,0 +1,16 @@
+import htm from 'sinuous/htm';
+import { context } from './hydrate.js';
+export { hydrate, _ } from './hydrate.js';
+
+export const h = context();
+export const hs = context(true);
+
+// `export const html = htm.bind(h)` is not tree-shakeable!
+export function html() {
+  return htm.apply(h, arguments);
+}
+
+// `export const svg = htm.bind(hs)` is not tree-shakeable!
+export function svg() {
+  return htm.apply(hs, arguments);
+}

--- a/packages/sinuous/hydrate/test/.eslintrc.yml
+++ b/packages/sinuous/hydrate/test/.eslintrc.yml
@@ -1,0 +1,9 @@
+---
+env:
+  mocha: true
+
+globals:
+  assert: false
+  should: false
+  expect: false
+  sinon: false

--- a/packages/sinuous/hydrate/test/hydrate.js
+++ b/packages/sinuous/hydrate/test/hydrate.js
@@ -1,0 +1,384 @@
+import test from 'tape';
+import spy from 'ispy';
+import { normalizeSvg } from '../../test/_utils.js';
+import { h, hs, html, svg, hydrate, _ } from 'sinuous/hydrate';
+import { observable } from 'sinuous';
+
+test('hydrate adds event listeners', function(t) {
+  document.body.innerHTML = `
+    <div>
+      <button>something</button>
+    </div>
+  `;
+
+  const click = spy();
+  const delta = h('div', [
+    h('button', { onclick: click, title: 'Apply pressure' }, 'something')
+  ]);
+  const div = hydrate(delta, document.querySelector('div'));
+  const btn = div.children[0];
+  btn.click();
+  t.equal(click.callCount, 1, 'click called');
+
+  div.parentNode.removeChild(div);
+  t.end();
+});
+
+test('hydrate works with nested children and patches text', function(t) {
+  document.body.innerHTML = `
+    <div class="container">
+      <h1>Banana</h1>
+      <div class="main">
+        <button>Cherry</button>
+        Text node
+      </div>
+    </div>
+  `;
+
+  const delta = html`
+    <div class="container">
+      <h1>Banana milkshake</h1>
+      <div class="main">
+        <button>Cherry</button>
+        Text node patch
+      </div>
+    </div>
+  `;
+
+  t.deepEqual(delta, {
+    _tag: 'div',
+    _props: { class: 'container' },
+    _children: [
+      { _tag: 'h1', _children: ['Banana milkshake'] },
+      { _tag: 'div', _props: { class: 'main' }, _children: [
+        { _tag: 'button', _children: ['Cherry'] },
+        'Text node patch'
+      ] }
+    ]
+  });
+
+  const div = hydrate(delta, document.querySelector('div'));
+
+  t.equal(
+    div.outerHTML,
+    `<div class="container">
+      <h1>Banana milkshake</h1>
+      <div class="main">
+        <button>Cherry</button>Text node patch</div>
+    </div>`
+  );
+
+  div.parentNode.removeChild(div);
+  t.end();
+});
+
+test('hydrate can add observables', function(t) {
+  document.body.innerHTML = `
+    <div>
+      0
+      <button>off</button>
+      0
+    </div>
+  `;
+
+  const count = observable(0);
+  const toggle = observable('off');
+  const delta = h('div', [
+    count,
+    h('button', { class: 'toggle' }, toggle),
+    count
+  ]);
+  const div = hydrate(delta, document.querySelector('div'));
+  count(1);
+
+  t.equal(
+    div.outerHTML,
+    `<div>1<button class="toggle">off</button>1</div>`
+  );
+
+  count(22);
+  toggle('on');
+
+  t.equal(
+    div.outerHTML,
+    `<div>22<button class="toggle">on</button>22</div>`
+  );
+
+  div.parentNode.removeChild(div);
+  t.end();
+});
+
+test('hydrate can add conditional observables in tags', function(t) {
+  document.body.innerHTML = `
+    <div class="hamburger">
+      <span>Pickle</span>
+      <span>Ketchup</span>
+      <span>Cheese</span>
+      <span>Ham</span>
+    </div>
+  `;
+
+  const sauce = observable('');
+  const delta = html`
+    <div class="hamburger">
+      <span>Pickle</span>
+      <span>${() => sauce() === 'mayo' ? 'Mayo' : 'Ketchup'}</span>
+      <span>Cheese</span>
+      <span>Ham</span>
+    </div>
+  `;
+  const div = hydrate(delta, document.querySelector('div'));
+
+  t.equal(
+    div.outerHTML,
+    `<div class="hamburger">
+      <span>Pickle</span>
+      <span>Ketchup</span>
+      <span>Cheese</span>
+      <span>Ham</span>
+    </div>`
+  );
+
+  sauce('mayo');
+
+  t.equal(
+    div.outerHTML,
+    `<div class="hamburger">
+      <span>Pickle</span>
+      <span>Mayo</span>
+      <span>Cheese</span>
+      <span>Ham</span>
+    </div>`
+  );
+
+  div.parentNode.removeChild(div);
+  t.end();
+});
+
+test('hydrate works with a placeholder character', function(t) {
+  document.body.innerHTML = `
+    <div class="container">
+      <h1>Banana</h1>
+      <div class="main">
+        <button>Cherry</button>
+        Text node
+        <button class="btn">Bom</button>
+      </div>
+    </div>
+  `;
+
+  const click = spy();
+  const delta = html`
+    <div>
+      <h1>${_}</h1>
+      <div>
+        <button>${_}</button>
+        ${_}
+        <button class="btn" onclick=${click}>Bom</button>
+      </div>
+    </div>
+  `;
+  const div = hydrate(delta, document.querySelector('div'));
+  const btn = div.querySelector('.btn');
+  btn.click();
+  t.equal(click.callCount, 1, 'click called');
+
+  t.equal(
+    div.outerHTML,
+    `<div class="container">
+      <h1>Banana</h1>
+      <div class="main">
+        <button>Cherry</button>
+        Text node
+        <button class="btn">Bom</button>
+      </div>
+    </div>`
+  );
+
+  div.parentNode.removeChild(div);
+  t.end();
+});
+
+test('supports hydrating SVG via hyperscript', function(t) {
+  document.body.innerHTML = `<svg class="redbox" viewBox="0 0 100 100"><path d="M 8.74211 7.70899"></path></svg>`;
+
+  const delta = hs(
+    'svg',
+    { class: 'redbox', viewBox: '0 0 100 100' },
+    hs('path', { d: 'M 8.74211 7.70899' })
+  );
+
+  const svg = hydrate(delta, document.querySelector('svg'));
+
+  t.equal(
+    normalizeSvg(svg),
+    '<svg class="redbox" viewBox="0 0 100 100"><path d="M 8.74211 7.70899"></path></svg>'
+  );
+  t.end();
+});
+
+test('supports hydrating SVG', function(t) {
+  document.body.innerHTML = `<svg class="redbox" viewBox="0 0 100 100"><path d="M 8.74211 7.70899"></path></svg>`;
+
+  const delta = svg`
+    <svg class="redbox" viewBox="0 0 100 100">
+      <path d="M 8.74211 7.70899"></path>
+    </svg>
+  `;
+
+  const el = hydrate(delta, document.querySelector('svg'));
+
+  t.equal(
+    normalizeSvg(el),
+    '<svg class="redbox" viewBox="0 0 100 100"><path d="M 8.74211 7.70899"></path></svg>'
+  );
+  t.end();
+});
+
+test('can hydrate an array of svg elements', function(t) {
+  document.body.innerHTML = `<svg><circle cx="0" cy="1" r="10"></circle><circle cx="0" cy="2" r="10"></circle><circle cx="0" cy="3" r="10"></circle><rect></rect><circle cx="0" cy="1" r="10"></circle><circle cx="0" cy="2" r="10"></circle><circle cx="0" cy="3" r="10"></circle></svg>`;
+
+  const circles = observable([1, 2, 3]);
+  const delta = svg`<svg>
+    ${() => circles().map(c => svg`<circle cx="0" cy="${c}" r="10" />`)}
+    <rect></rect>
+    ${() => circles().map(c => svg`<circle cx="0" cy="${c}" r="10" />`)}
+  </svg>`;
+
+  const el = hydrate(delta, document.querySelector('svg'));
+
+  t.equal(
+    normalizeSvg(el),
+    '<svg><circle cx="0" cy="1" r="10"></circle><circle cx="0" cy="2" r="10"></circle><circle cx="0" cy="3" r="10"></circle><rect/><circle cx="0" cy="1" r="10"></circle><circle cx="0" cy="2" r="10"></circle><circle cx="0" cy="3" r="10"></circle></svg>'
+  );
+
+  circles([1, 2, 3, 4]);
+
+  t.equal(
+    normalizeSvg(el),
+    '<svg><circle cx="0" cy="1" r="10"></circle><circle cx="0" cy="2" r="10"></circle><circle cx="0" cy="3" r="10"></circle><circle cx="0" cy="4" r="10"></circle><rect/><circle cx="0" cy="1" r="10"></circle><circle cx="0" cy="2" r="10"></circle><circle cx="0" cy="3" r="10"></circle><circle cx="0" cy="4" r="10"></circle></svg>'
+  );
+
+  t.end();
+});
+
+test('hydrate can add a node from function', function(t) {
+  document.body.innerHTML = `
+    <div>
+      <span>Pear</span>
+    </div>
+  `;
+
+  const fruit = observable('Pear');
+  const delta = html`
+    <div>
+      ${() => html`<span>${fruit}</span>`}
+    </div>
+  `;
+  const div = hydrate(delta, document.querySelector('div'));
+
+  t.equal(
+    div.outerHTML,
+    `<div>
+      <span>Pear</span>
+    </div>`
+  );
+
+  fruit('Apple');
+
+  t.equal(
+    div.outerHTML,
+    `<div>
+      <span>Apple</span>
+    </div>`
+  );
+
+  div.parentNode.removeChild(div);
+  t.end();
+});
+
+test('hydrate can add a fragment from function', function(t) {
+  document.body.innerHTML = `
+    <div>
+      <span>Pear</span>
+      <span>Banana</span>
+      <span>Tomato</span>
+    </div>
+  `;
+
+  const fruit = observable('Pear');
+  const veggie = observable('Tomato');
+  const delta = html`
+    <div>
+      ${() => html`
+        <span>${fruit}</span>
+        <span>Banana</span>
+        ${() => html`<span>${veggie}</span>`}
+      `}
+    </div>
+  `;
+  const div = hydrate(delta, document.querySelector('div'));
+
+  t.equal(
+    div.outerHTML,
+    `<div>
+      <span>Pear</span>
+      <span>Banana</span>
+      <span>Tomato</span>
+    </div>`
+  );
+
+  fruit('Apple');
+  veggie('Potato');
+
+  t.equal(
+    div.outerHTML,
+    `<div>
+      <span>Apple</span>
+      <span>Banana</span>
+      <span>Potato</span>
+    </div>`
+  );
+
+  div.parentNode.removeChild(div);
+  t.end();
+});
+
+test('hydrate can add conditional observables in content', function(t) {
+  document.body.innerHTML = `
+    <div class="hamburger">
+      Pickle
+      Ketchup
+      Cheese
+      Ham
+    </div>
+  `;
+
+  const sauce = observable('');
+  const delta = html`
+    <div class="hamburger">
+      Pickle
+      ${() => sauce() === 'mayo' ? ' Mayo ' : ' Ketchup '}
+      Cheese
+      Ham
+    </div>
+  `;
+  const div = hydrate(delta, document.querySelector('div'));
+
+  t.equal(
+    div.outerHTML,
+    `<div class="hamburger">Pickle Ketchup Cheese
+      Ham</div>`
+  );
+
+  sauce('mayo');
+
+  t.equal(
+    div.outerHTML,
+    `<div class="hamburger">Pickle Mayo Cheese
+      Ham</div>`
+  );
+
+  div.parentNode.removeChild(div);
+  t.end();
+});

--- a/packages/sinuous/map/mini/src/mini.js
+++ b/packages/sinuous/map/mini/src/mini.js
@@ -38,6 +38,12 @@ export function map(items, expr) {
     const beforeNodeIndex = EMPTY_ARR.indexOf.call(childNodes, beforeNode);
     const afterNodeIndex = EMPTY_ARR.indexOf.call(childNodes, afterNode);
 
+    // Optimization
+    // const afterNodeIndex =
+    //   childNodes.pop() === afterNode
+    //     ? childNodes.length
+    //     : EMPTY_ARR.indexOf.call(childNodes, afterNode);
+
     // Create a mapping from keys to their position in the old list
     for (i = 0; i < a.length; i++) {
       aIdx.set(a[i], i);

--- a/packages/sinuous/package.json
+++ b/packages/sinuous/package.json
@@ -20,7 +20,9 @@
     "map/mini",
     "map/package.json",
     "template/src",
-    "template/package.json"
+    "template/package.json",
+    "hydrate/package.json",
+    "hydrate/src"
   ],
   "peerDependencies": {
     "sinuous": ">=0.6.0"

--- a/packages/sinuous/test/test.js
+++ b/packages/sinuous/test/test.js
@@ -23,3 +23,4 @@ import '../map/test/utils.js';
 import '../map/mini/test/mini.js';
 import '../map/mini/test/mini-basic.js';
 import '../template/test/template.js';
+import '../hydrate/test/hydrate.js';

--- a/scripts/bundles.js
+++ b/scripts/bundles.js
@@ -23,6 +23,15 @@ export const bundles = [
     dest: dest()
   },
   {
+    // order is important, every even pkg name is replaced w/ next uneven file in ESM
+    external: ['sinuous', './sinuous.js', 'sinuous/htm', './htm.js'],
+    formats: [ESM, UMD, IIFE],
+    global: 'hydrate',
+    name: 'hydrate',
+    input: 'packages/sinuous/hydrate/src/index.js',
+    dest: dest()
+  },
+  {
     external: [],
     formats: [ESM, UMD, IIFE],
     global: 'observable',

--- a/scripts/rollup/config.js
+++ b/scripts/rollup/config.js
@@ -109,10 +109,9 @@ function getConfig(options) {
             props: {
               cname: 6,
               props: {
-                // $_observable: '__o',
-                // $_observables: '__o',
-                // $_children: '__c',
-                // $_update: '__u'
+                $_tag: '__t',
+                $_props: '__p',
+                $_children: '__c'
               }
             }
           }


### PR DESCRIPTION
Implements issue #26.

A lot of times HTML is better build without javascript initially but when the initial render is done event handlers and dynamic functionality have to be added without re-creating the DOM. This is what `hydrate` is for.