### PR TITLE
Rename html to dhtml and related

### DIFF
--- a/packages/sinuous/all/test/all.js
+++ b/packages/sinuous/all/test/all.js
@@ -23,10 +23,10 @@ test('test functions exist on namespace S', function(t) {
   t.equal(typeof S.isListening, 'function', 'no isListening fun');
 
   t.equal(typeof S.hydrate.hydrate, 'function', 'no hydrate.hydrate fun');
-  t.equal(typeof S.hydrate.html, 'function', 'no hydrate.html fun');
-  t.equal(typeof S.hydrate.svg, 'function', 'no hydrate.svg fun');
-  t.equal(typeof S.hydrate.h, 'function', 'no hydrate.h fun');
-  t.equal(typeof S.hydrate.hs, 'function', 'no hydrate.hs fun');
+  t.equal(typeof S.hydrate.dhtml, 'function', 'no hydrate.dhtml fun');
+  t.equal(typeof S.hydrate.dsvg, 'function', 'no hydrate.dsvg fun');
+  t.equal(typeof S.hydrate.dh, 'function', 'no hydrate.dh fun');
+  t.equal(typeof S.hydrate.dhs, 'function', 'no hydrate.dhs fun');
 
   t.end();
 });

--- a/packages/sinuous/all/test/all.js
+++ b/packages/sinuous/all/test/all.js
@@ -25,8 +25,8 @@ test('test functions exist on namespace S', function(t) {
   t.equal(typeof S.hydrate.hydrate, 'function', 'no hydrate.hydrate fun');
   t.equal(typeof S.hydrate.dhtml, 'function', 'no hydrate.dhtml fun');
   t.equal(typeof S.hydrate.dsvg, 'function', 'no hydrate.dsvg fun');
-  t.equal(typeof S.hydrate.dh, 'function', 'no hydrate.dh fun');
-  t.equal(typeof S.hydrate.dhs, 'function', 'no hydrate.dhs fun');
+  t.equal(typeof S.hydrate.d, 'function', 'no hydrate.d fun');
+  t.equal(typeof S.hydrate.ds, 'function', 'no hydrate.ds fun');
 
   t.end();
 });

--- a/packages/sinuous/hydrate/src/index.d.ts
+++ b/packages/sinuous/hydrate/src/index.d.ts
@@ -30,7 +30,7 @@ export function hydrate(delta: VNode, root?: Node): Node;
 export const dhtml: (strings: TemplateStringsArray, ...values: any[]) => VNode | VNode[];
 export const dsvg: (strings: TemplateStringsArray, ...values: any[]) => VNode | VNode[];
 
-export function dh(
+export function d(
   type: string,
   props:
     | JSXInternal.HTMLAttributes &
@@ -38,7 +38,7 @@ export function dh(
     | null,
   ...children: ElementChildren[]
 ): VNode | VNode[];
-export function dh(
+export function d(
   type: FunctionComponent,
   props:
     | JSXInternal.HTMLAttributes &
@@ -46,14 +46,14 @@ export function dh(
     | null,
   ...children: ElementChildren[]
 ): VNode | VNode[];
-export function dh(
+export function d(
   children: ElementChildren[]
 ): VNode | VNode[];
-export namespace dh {
+export namespace d {
   export import JSX = JSXInternal;
 }
 
-export function dhs(
+export function ds(
   type: string,
   props:
     | JSXInternal.SVGAttributes &
@@ -61,7 +61,7 @@ export function dhs(
     | null,
   ...children: ElementChildren[]
 ): VNode | VNode[];
-export function dhs(
+export function ds(
   type: FunctionComponent,
   props:
     | JSXInternal.SVGAttributes &
@@ -69,9 +69,9 @@ export function dhs(
     | null,
   ...children: ElementChildren[]
 ): VNode | VNode[];
-export function dhs(
+export function ds(
   children: ElementChildren[]
 ): VNode | VNode[];
-export namespace dhs {
+export namespace ds {
   export import JSX = JSXInternal;
 }

--- a/packages/sinuous/hydrate/src/index.d.ts
+++ b/packages/sinuous/hydrate/src/index.d.ts
@@ -27,10 +27,10 @@ interface FunctionComponent<P = {}> {
 
 export function hydrate(delta: VNode, root?: Node): Node;
 
-export const html: (strings: TemplateStringsArray, ...values: any[]) => VNode | VNode[];
-export const svg: (strings: TemplateStringsArray, ...values: any[]) => VNode | VNode[];
+export const dhtml: (strings: TemplateStringsArray, ...values: any[]) => VNode | VNode[];
+export const dsvg: (strings: TemplateStringsArray, ...values: any[]) => VNode | VNode[];
 
-export function h(
+export function dh(
   type: string,
   props:
     | JSXInternal.HTMLAttributes &
@@ -38,7 +38,7 @@ export function h(
     | null,
   ...children: ElementChildren[]
 ): VNode | VNode[];
-export function h(
+export function dh(
   type: FunctionComponent,
   props:
     | JSXInternal.HTMLAttributes &
@@ -46,14 +46,14 @@ export function h(
     | null,
   ...children: ElementChildren[]
 ): VNode | VNode[];
-export function h(
+export function dh(
   children: ElementChildren[]
 ): VNode | VNode[];
-export namespace h {
+export namespace dh {
   export import JSX = JSXInternal;
 }
 
-export function hs(
+export function dhs(
   type: string,
   props:
     | JSXInternal.SVGAttributes &
@@ -61,7 +61,7 @@ export function hs(
     | null,
   ...children: ElementChildren[]
 ): VNode | VNode[];
-export function hs(
+export function dhs(
   type: FunctionComponent,
   props:
     | JSXInternal.SVGAttributes &
@@ -69,9 +69,9 @@ export function hs(
     | null,
   ...children: ElementChildren[]
 ): VNode | VNode[];
-export function hs(
+export function dhs(
   children: ElementChildren[]
 ): VNode | VNode[];
-export namespace hs {
+export namespace dhs {
   export import JSX = JSXInternal;
 }

--- a/packages/sinuous/hydrate/src/index.js
+++ b/packages/sinuous/hydrate/src/index.js
@@ -2,15 +2,15 @@ import htm from 'sinuous/htm';
 import { context } from './hydrate.js';
 export { hydrate, _ } from './hydrate.js';
 
-export const h = context();
-export const hs = context(true);
+export const dh = context();
+export const dhs = context(true);
 
 // `export const html = htm.bind(h)` is not tree-shakeable!
-export function html() {
-  return htm.apply(h, arguments);
+export function dhtml() {
+  return htm.apply(dh, arguments);
 }
 
 // `export const svg = htm.bind(hs)` is not tree-shakeable!
-export function svg() {
-  return htm.apply(hs, arguments);
+export function dsvg() {
+  return htm.apply(dhs, arguments);
 }

--- a/packages/sinuous/hydrate/src/index.js
+++ b/packages/sinuous/hydrate/src/index.js
@@ -2,15 +2,15 @@ import htm from 'sinuous/htm';
 import { context } from './hydrate.js';
 export { hydrate, _ } from './hydrate.js';
 
-export const dh = context();
-export const dhs = context(true);
+export const d = context();
+export const ds = context(true);
 
 // `export const html = htm.bind(h)` is not tree-shakeable!
 export function dhtml() {
-  return htm.apply(dh, arguments);
+  return htm.apply(d, arguments);
 }
 
 // `export const svg = htm.bind(hs)` is not tree-shakeable!
 export function dsvg() {
-  return htm.apply(dhs, arguments);
+  return htm.apply(ds, arguments);
 }

--- a/packages/sinuous/hydrate/test/hydrate.js
+++ b/packages/sinuous/hydrate/test/hydrate.js
@@ -1,6 +1,6 @@
 import test from 'tape';
 import spy from 'ispy';
-import { dh, dhtml, hydrate, _ } from 'sinuous/hydrate';
+import { d, dhtml, hydrate, _ } from 'sinuous/hydrate';
 import { observable, html } from 'sinuous';
 
 test('hydrates root bug', function(t) {
@@ -107,8 +107,8 @@ test('hydrate adds event listeners', function(t) {
   `;
 
   const click = spy();
-  const delta = dh('div', [
-    dh('button', { onclick: click, title: 'Apply pressure' }, 'something')
+  const delta = d('div', [
+    d('button', { onclick: click, title: 'Apply pressure' }, 'something')
   ]);
   const div = hydrate(delta, document.querySelector('div'));
   const btn = div.children[0];
@@ -166,9 +166,9 @@ test('hydrate can add observables', function(t) {
 
   const count = observable(0);
   const toggle = observable('off');
-  const delta = dh('div', [
+  const delta = d('div', [
     count,
-    dh('button', { class: 'toggle' }, toggle),
+    d('button', { class: 'toggle' }, toggle),
     count
   ]);
   const div = hydrate(delta, document.querySelector('div'));

--- a/packages/sinuous/hydrate/test/hydrate.js
+++ b/packages/sinuous/hydrate/test/hydrate.js
@@ -1,14 +1,14 @@
 import test from 'tape';
 import spy from 'ispy';
-import { h, html, hydrate, _ } from 'sinuous/hydrate';
-import { observable, html as newhtml } from 'sinuous';
+import { dh, dhtml, hydrate, _ } from 'sinuous/hydrate';
+import { observable, html } from 'sinuous';
 
 test('hydrates root bug', function(t) {
   document.body.innerHTML = `
     <img class="hidden" />
   `;
 
-  const img = hydrate(html`
+  const img = hydrate(dhtml`
     <img class="hidden block" />
   `, document.querySelector('img'));
 
@@ -23,7 +23,7 @@ test('hydrate function undefined bug', function(t) {
     </div>
   `;
 
-  const div = hydrate(html`
+  const div = hydrate(dhtml`
     <div class="navbar-item">
       <a>${() => undefined}</a>
     </div>
@@ -40,7 +40,7 @@ test('hydrate function bug', function(t) {
     </div>
   `;
 
-  const div = hydrate(html`
+  const div = hydrate(dhtml`
     <div class="navbar-item">
       <a>${() => 'Wesley'}</a>
     </div>
@@ -71,7 +71,7 @@ test('hydrate w/ observables bug', function(t) {
   const up = spy();
   up.delegate = () => count(count() + 1);
 
-  const delta = html`
+  const delta = dhtml`
     <div class="box level">
       <div class="level-item">
         <button class="button" onclick="${down}">
@@ -107,8 +107,8 @@ test('hydrate adds event listeners', function(t) {
   `;
 
   const click = spy();
-  const delta = h('div', [
-    h('button', { onclick: click, title: 'Apply pressure' }, 'something')
+  const delta = dh('div', [
+    dh('button', { onclick: click, title: 'Apply pressure' }, 'something')
   ]);
   const div = hydrate(delta, document.querySelector('div'));
   const btn = div.children[0];
@@ -130,7 +130,7 @@ test('hydrate works with nested children and patches text', function(t) {
     </div>
   `;
 
-  const delta = html`
+  const delta = dhtml`
     <div class="container">
       <h1>Banana milkshake</h1>
       <div class="main">
@@ -166,9 +166,9 @@ test('hydrate can add observables', function(t) {
 
   const count = observable(0);
   const toggle = observable('off');
-  const delta = h('div', [
+  const delta = dh('div', [
     count,
-    h('button', { class: 'toggle' }, toggle),
+    dh('button', { class: 'toggle' }, toggle),
     count
   ]);
   const div = hydrate(delta, document.querySelector('div'));
@@ -202,7 +202,7 @@ test('hydrate can add conditional observables in tags', function(t) {
   `;
 
   const sauce = observable('');
-  const delta = html`
+  const delta = dhtml`
     <div class="hamburger">
       <span>Pickle</span>
       <span>${() => sauce() === 'mayo' ? 'Mayo' : 'Ketchup'}</span>
@@ -251,7 +251,7 @@ test('hydrate works with a placeholder character', function(t) {
   `;
 
   const click = spy();
-  const delta = html`
+  const delta = dhtml`
     <div>
       <h1>${_}</h1>
       <div>
@@ -290,9 +290,9 @@ test('hydrate can add a node from function', function(t) {
   `;
 
   const fruit = observable('Pear');
-  const delta = html`
+  const delta = dhtml`
     <div>
-      ${() => html`<span>${fruit}</span>`}
+      ${() => dhtml`<span>${fruit}</span>`}
     </div>
   `;
   const div = hydrate(delta, document.querySelector('div'));
@@ -328,12 +328,12 @@ test('hydrate can add a fragment from function', function(t) {
 
   const fruit = observable('Pear');
   const veggie = observable('Tomato');
-  const delta = html`
+  const delta = dhtml`
     <div>
-      ${() => html`
+      ${() => dhtml`
         <span>${fruit}</span>
         <span>Banana</span>
-        ${() => html`<span>${veggie}</span>`}
+        ${() => dhtml`<span>${veggie}</span>`}
       `}
     </div>
   `;
@@ -371,7 +371,7 @@ test('hydrates adjacent text nodes', function(t) {
 
   const greeting = observable('Hi');
   const name = observable('John Snow');
-  const delta = html`
+  const delta = dhtml`
     <div>${greeting} ${name}<span>!</span></div>
   `;
   const div = hydrate(delta, document.querySelector('div'));
@@ -398,7 +398,7 @@ test('hydrate can add conditional observables in content', function(t) {
   `;
 
   const sauce = observable('');
-  const delta = html`
+  const delta = dhtml`
     <div class="hamburger">
       Pickle ${() => sauce() === 'mayo' ? 'Mayo' : 'Ketchup'} Cheese Ham
     </div>
@@ -432,7 +432,7 @@ test('hydrate can add conditional observables in content w/ newlines', function(
   `;
 
   const sauce = observable('');
-  const delta = html`
+  const delta = dhtml`
     <div class="hamburger">
       Pickle
       ${() => sauce() === 'mayo' ? 'Mayo' : 'Ketchup'}
@@ -477,7 +477,7 @@ test('hydrate can create dom after hydration', function(t) {
 
   const avatar = observable('W');
 
-  const button = hydrate(html`
+  const button = hydrate(dhtml`
     <button>
       ${avatar}
     </button>
@@ -485,7 +485,7 @@ test('hydrate can create dom after hydration', function(t) {
 
   t.equal(button.childNodes[0].textContent, 'W');
 
-  avatar(newhtml`
+  avatar(html`
     W
     <img class="hidden" src="https://sinuous.io/" />
   `);
@@ -507,14 +507,14 @@ test('hydrate components', function(t) {
   const name = observable('Wes');
 
   const Name = (props) => {
-    return html`
+    return dhtml`
       <div class="name hidden">
         <span>${props.text}</span>
       </div>
     `;
   };
 
-  const div = hydrate(html`
+  const div = hydrate(dhtml`
     <div id="wrap">
       <${Name} text=${name} />
     </div>
@@ -540,14 +540,14 @@ test('hydrate root component', function(t) {
   const name = observable('Wes');
 
   const Name = (props) => {
-    return html`
+    return dhtml`
       <div class="name">
         <span>${props.text}</span>
       </div>
     `;
   };
 
-  const div = hydrate(html`
+  const div = hydrate(dhtml`
     <${Name} text=${name} />
   `);
 

--- a/packages/sinuous/hydrate/test/selector.js
+++ b/packages/sinuous/hydrate/test/selector.js
@@ -1,5 +1,5 @@
 import test from 'tape';
-import { html, hydrate } from 'sinuous/hydrate';
+import { dhtml, hydrate } from 'sinuous/hydrate';
 import { observable } from 'sinuous';
 
 test('hydrate selects root node via id selector', function(t) {
@@ -9,7 +9,7 @@ test('hydrate selects root node via id selector', function(t) {
     </div>
   `;
 
-  const div = hydrate(html`
+  const div = hydrate(dhtml`
     <div id="root">
       <button title="Apply pressure">something</button>
     </div>
@@ -28,7 +28,7 @@ test('hydrate selects root node via class selector', function(t) {
     </div>
   `;
 
-  const div = hydrate(html`
+  const div = hydrate(dhtml`
     <div class="root pure">
       <button title="Apply pressure">something</button>
     </div>
@@ -50,7 +50,7 @@ test('hydrate selects root node via partial class selector', function(t) {
   `;
 
   const isActive = observable('');
-  const div = hydrate(html`
+  const div = hydrate(dhtml`
     <div class="root pure${isActive}">
       <button
         onclick=${() => isActive(isActive() ? '' : ' is-active')}

--- a/packages/sinuous/hydrate/test/svg.js
+++ b/packages/sinuous/hydrate/test/svg.js
@@ -1,15 +1,15 @@
 import test from 'tape';
 import { normalizeSvg } from '../../test/_utils.js';
-import { dhs, dsvg, hydrate } from 'sinuous/hydrate';
+import { ds, dsvg, hydrate } from 'sinuous/hydrate';
 import { observable } from 'sinuous';
 
 test('supports hydrating SVG via hyperscript', function(t) {
   document.body.innerHTML = `<svg class="redbox" viewBox="0 0 100 100"><path d="M 8.74211 7.70899"></path></svg>`;
 
-  const delta = dhs(
+  const delta = ds(
     'svg',
     { class: 'redbox', viewBox: '0 0 100 100' },
-    dhs('path', { d: 'M 8.74211 7.70899' })
+    ds('path', { d: 'M 8.74211 7.70899' })
   );
 
   const svg = hydrate(delta, document.querySelector('svg'));

--- a/packages/sinuous/hydrate/test/svg.js
+++ b/packages/sinuous/hydrate/test/svg.js
@@ -1,15 +1,15 @@
 import test from 'tape';
 import { normalizeSvg } from '../../test/_utils.js';
-import { hs, svg, hydrate } from 'sinuous/hydrate';
+import { dhs, dsvg, hydrate } from 'sinuous/hydrate';
 import { observable } from 'sinuous';
 
 test('supports hydrating SVG via hyperscript', function(t) {
   document.body.innerHTML = `<svg class="redbox" viewBox="0 0 100 100"><path d="M 8.74211 7.70899"></path></svg>`;
 
-  const delta = hs(
+  const delta = dhs(
     'svg',
     { class: 'redbox', viewBox: '0 0 100 100' },
-    hs('path', { d: 'M 8.74211 7.70899' })
+    dhs('path', { d: 'M 8.74211 7.70899' })
   );
 
   const svg = hydrate(delta, document.querySelector('svg'));
@@ -24,7 +24,7 @@ test('supports hydrating SVG via hyperscript', function(t) {
 test('supports hydrating SVG', function(t) {
   document.body.innerHTML = `<svg class="redbox" viewBox="0 0 100 100"><path d="M 8.74211 7.70899"></path></svg>`;
 
-  const delta = svg`
+  const delta = dsvg`
     <svg class="redbox" viewBox="0 0 100 100">
       <path d="M 8.74211 7.70899"></path>
     </svg>
@@ -43,10 +43,10 @@ test('can hydrate an array of svg elements', function(t) {
   document.body.innerHTML = `<svg><circle cx="0" cy="1" r="10"></circle><circle cx="0" cy="2" r="10"></circle><circle cx="0" cy="3" r="10"></circle><rect x="0"></rect><circle cx="0" cy="1" r="10"></circle><circle cx="0" cy="2" r="10"></circle><circle cx="0" cy="3" r="10"></circle></svg>`;
 
   const circles = observable([1, 2, 3]);
-  const delta = svg`<svg>
-    ${() => circles().map(c => svg`<circle cx="0" cy="${c}" r="10" />`)}
+  const delta = dsvg`<svg>
+    ${() => circles().map(c => dsvg`<circle cx="0" cy="${c}" r="10" />`)}
     <rect x="0"></rect>
-    ${() => circles().map(c => svg`<circle cx="0" cy="${c}" r="10" />`)}
+    ${() => circles().map(c => dsvg`<circle cx="0" cy="${c}" r="10" />`)}
   </svg>`;
 
   const el = hydrate(delta, document.querySelector('svg'));


### PR DESCRIPTION
This to avoid naming conflicts where you would hydrate some parts and create new DOM in other parts.

- ` html`` ` in `sinuous`: creates new DOM, returns an element
- ` dhtml`` ` in `sinuous/hydrate`: used for hydration, returns a tree like object structure
- ` rhtml`` ` in `sinuous/render`: used for top/down rendering, returns a function

