### PR TITLE
Add lazy executed component children

### DIFF
--- a/packages/sinuous/babel-plugin-htm/src/index.js
+++ b/packages/sinuous/babel-plugin-htm/src/index.js
@@ -132,9 +132,12 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
     if (node === undefined) return t.identifier('undefined');
 
     const { tag, props, children } = node;
-    const newTag = typeof tag === 'string' ? t.stringLiteral(tag) : tag;
+    const isComponent = typeof tag !== 'string';
+    const newTag = isComponent ? tag : t.stringLiteral(tag);
     const newProps = spreadNode(props, state);
-    const newChildren = t.arrayExpression((children || []).map(child => transform(child, state)));
+    const newChildren = t.arrayExpression((children || [])
+      .map(child => transform(child, state))
+      .map(child => isComponent ? t.arrowFunctionExpression([], child) : child));
     return createVNode(newTag, newProps, newChildren);
   }
 

--- a/packages/sinuous/htm/src/build.js
+++ b/packages/sinuous/htm/src/build.js
@@ -112,7 +112,11 @@ export const evaluate = (h, built, fields, args) => {
     }
     else if (type) {
       // code === CHILD_RECURSE
-      args.push(h.apply(null, evaluate(h, value, fields, ['', null])));
+      const result = () => h.apply(null, evaluate(h, value, fields, ['', null]));
+
+      // if it's a component we pass the children with closure so the
+      // component is executed before the children of that component.
+      args.push(typeof args[0] === 'function' ? result : result());
     }
     else {
       // code === CHILD_APPEND

--- a/packages/sinuous/htm/test/babel.js
+++ b/packages/sinuous/htm/test/babel.js
@@ -326,6 +326,69 @@ describe('htm/babel', () => {
     t.end();
   });
 
+  test('should add children without closure', t => {
+    t.equal(
+      transform('html`<div><b /></div>`;', {
+        ...options,
+        plugins: [
+          [
+            htmBabelPlugin
+          ]
+        ]
+      }).code,
+      `h("div",null,h("b",null));`
+    );
+    t.equal(
+      transform('html`<div><b /><i /></div>`;', {
+        ...options,
+        plugins: [
+          [
+            htmBabelPlugin
+          ]
+        ]
+      }).code,
+      `h("div",null,h("b",null),h("i",null));`
+    );
+    t.end();
+  });
+
+  test('should wrap children of component in closure', t => {
+    t.equal(
+      transform('html`<${Component}><div></div><//>`;', {
+        ...options,
+        plugins: [
+          [
+            htmBabelPlugin
+          ]
+        ]
+      }).code,
+      `h(Component,null,()=>h("div",null));`
+    );
+    t.equal(
+      transform('html`<${Component}><div /><b /><//>`;', {
+        ...options,
+        plugins: [
+          [
+            htmBabelPlugin
+          ]
+        ]
+      }).code,
+      `h(Component,null,()=>h("div",null),()=>h("b",null));`
+    );
+    t.equal(
+      transform('html`<${Component}><div><${Component}><b /><//></div><//>`;', {
+        ...options,
+        plugins: [
+          [
+            htmBabelPlugin
+          ]
+        ]
+      }).code,
+      `h(Component,null,()=>h("div",null,h(Component,null,()=>h("b",null))));`
+    );
+    t.end();
+  });
+
   describe('{variableArity:false}', () => {
     test('should pass no children as an empty Array', t => {
       t.equal(

--- a/packages/sinuous/package.json
+++ b/packages/sinuous/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sinuous",
-  "version": "0.23.3",
+  "version": "0.24.0-beta.0",
   "description": "🧬 Small, fast, reactive render engine",
   "module": "module/sinuous.js",
   "main": "dist/sinuous.js",

--- a/packages/sinuous/test/.eslintrc.yml
+++ b/packages/sinuous/test/.eslintrc.yml
@@ -5,3 +5,4 @@ env:
 rules:
   fp/no-mutating-methods: off
   fp/no-loops: off
+  fp/no-rest-parameters: off

--- a/packages/sinuous/test/sinuous.js
+++ b/packages/sinuous/test/sinuous.js
@@ -1,5 +1,6 @@
 import test from 'tape';
 import { o, html } from 'sinuous';
+import { fragInnerHTML } from './_utils.js';
 
 test('simple', function(t) {
   t.equal(
@@ -62,5 +63,27 @@ test('returns a simple observable string', t => {
   t.assert(frag instanceof DocumentFragment);
   t.assert(frag.childNodes[0] instanceof Text);
   t.equal(frag.childNodes[0].textContent, 'Banana');
+  t.end();
+});
+
+test('component children order', t => {
+  let order = '';
+  const Comp = (props, ...children) => {
+    order += 'a';
+    return children;
+  };
+  const Child = () => {
+    order += 'b';
+    return html`<b />`;
+  };
+
+  const result = html`
+    <${Comp}>
+      <${Child} />
+    <//>
+  `;
+
+  t.equal(order, 'ab');
+  t.equal(fragInnerHTML(result), '<b></b>');
   t.end();
 });


### PR DESCRIPTION
Related issue #60

This change wraps component children automatically in a closure so the component is executed before the children. 

