### PR TITLE
Update babel-plugin-htm to 3.0.0 and simplify upstream diff

### DIFF
--- a/packages/sinuous/babel-plugin-htm/README.md
+++ b/packages/sinuous/babel-plugin-htm/README.md
@@ -1,98 +1,13 @@
 # `babel-plugin-htm`
 
-A Babel plugin that compiles [htm] syntax to hyperscript, React.createElement, or just plain objects.
+A Babel plugin that compiles [htm] syntax to hyperscript, React.createElement,
+or just plain objects.
 
-## Usage
+This is a fork of the official plugin. You can compare the changes by diffing
+against the official [v3.0.0 release].
 
-Basic usage:
-
-```js
-[
-  [
-    'htm',
-    {
-      pragma: 'React.createElement'
-    }
-  ]
-];
-```
-
-```js
-// input:
-html`
-  <div id="foo">hello ${you}</div>
-`;
-
-// output:
-React.createElement('div', { id: 'foo' }, 'hello ', you);
-```
-
-## options
-
-### `pragma`
-
-The target "hyperscript" function to compile elements to (see [Babel docs]).
-Defaults to: `"h"`.
-
-### `tag=html`
-
-By default, `babel-plugin-htm` will process all Tagged Templates with a tag function named `html`. To use a different name, use the `tag` option in your Babel configuration:
-
-```js
-{"plugins":[
-  ["babel-plugin-htm", {
-    "tag": "myCustomHtmlFunction"
-  }]
-]}
-```
-
-### `useBuiltIns=false`
-
-`babel-plugin-htm` transforms prop spreads (`<a ...${b}>`) into `Object.assign()` calls. For browser support reasons, Babel's standard `_extends` helper is used by default. To use native `Object.assign` directly, pass `{useBuiltIns:true}`.
-
-### `variableArity=true`
-
-By default, `babel-plugin-htm` transpiles to the same output as JSX would, which assumes a target function of the form `h(type, props, ...children)`. If, for the purposes of optimization or simplification, you would like all calls to `h()` to be passed exactly 3 arguments, specify `{variableArity:false}` in your Babel config:
-
-```js
-html`
-  <div />
-`; // h('div', null, [])
-html`
-  <div a />
-`; // h('div', { a: true }, [])
-html`
-  <div>b</div>
-`; // h('div', null, ['b'])
-html`
-  <div a>b</div>
-`; // h('div', { a: true }, ['b'])
-```
-
-### `pragma=false` _(experimental)_
-
-Setting `pragma` to `false` changes the output to be plain objects instead of `h()` function calls:
-
-```js
-// input:
-html`<div id="foo">hello ${you}</div>`
-// output:
-{ tag:"div", props:{ id: "foo" }, children:["hello ", you] }
-```
-
-### `monomorphic` _(experimental)_
-
-Like `pragma=false` but converts all inline text to objects, resulting in the same object shape being used:
-
-```js
-// input:
-html`<div id="foo">hello ${you}</div>`
-// output:
-{ type: 1, tag:"div", props:{ id: "foo" }, text: null, children:[
-  { type: 3, tag: null, props: null, text: "hello ", children: null },
-  you
-] }
-```
+Documentation is in the readme on [babel-plugin-html]'s repo.
 
 [htm]: https://github.com/developit/htm
-[babel docs]: https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#pragma
+[v3.0.0 release]: https://github.com/developit/htm/blob/3.0.0/packages/babel-plugin-htm/index.mjs
+[babel-plugin-html]: https://github.com/developit/htm/tree/master/packages/babel-plugin-htm

--- a/packages/sinuous/babel-plugin-htm/package.json
+++ b/packages/sinuous/babel-plugin-htm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "babel-plugin-htm",
-	"version": "2.1.0",
+	"version": "3.0.0",
 	"description": "Babel plugin to compile htm's Tagged Template syntax to hyperscript or inline VNodes.",
 	"main": "../dist/babel-plugin-htm.js",
 	"module": "../module/babel-plugin-htm.js",

--- a/packages/sinuous/babel-plugin-htm/package.json
+++ b/packages/sinuous/babel-plugin-htm/package.json
@@ -9,5 +9,8 @@
 	],
 	"author": "Jason Miller <jason@developit.ca>",
 	"license": "Apache-2.0",
-	"homepage": "https://github.com/developit/htm/tree/master/packages/babel-plugin-htm"
+	"homepage": "https://github.com/developit/htm/tree/master/packages/babel-plugin-htm",
+	"devDependencies": {
+		"@babel/types": "^7.9.5"
+	}
 }

--- a/packages/sinuous/babel-plugin-htm/src/index.js
+++ b/packages/sinuous/babel-plugin-htm/src/index.js
@@ -13,14 +13,14 @@ import { build, treeify } from '../../htm/src/build.js';
  * @param {boolean} [options.wrapExpression=''] If set wraps the generated expression with a function passing the same arguments the tagged template would receive.
  */
 export default function htmBabelPlugin({ types: t }, options = {}) {
-  const pragmaString = options.pragma===false ? false : options.pragma || 'h';
-  const pragma = pragmaString===false ? false : dottedIdentifier(pragmaString);
+  const pragmaString = options.pragma === false ? false : options.pragma || 'h';
+  const pragma = pragmaString === false ? false : dottedIdentifier(pragmaString);
   const useBuiltIns = options.useBuiltIns;
   const useNativeSpread = options.useNativeSpread;
-  const inlineVNodes = options.monomorphic || pragma===false;
+  const inlineVNodes = options.monomorphic || pragma === false;
   const importDeclaration = pragmaImport(options.import || false);
   const wrapExpression = options.wrapExpression;
-  let fields;
+  const fields = new Map();
 
   function pragmaImport(imp) {
     if (pragmaString === false || imp === false) {
@@ -45,68 +45,15 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
     return t.importDeclaration([specifier], t.stringLiteral(module));
   }
 
-  const Program = {
-    exit(path, state) {
-      if (state.get('hasHtm') && importDeclaration) {
-        path.unshiftContainer('body', importDeclaration);
+  function dottedIdentifier(keypath) {
+    const path = keypath.split('.');
+    let out;
+    for (let i = 0; i < path.length; i++) {
+      const ident = propertyName(path[i]);
+      out = i === 0 ? ident : t.memberExpression(out, ident);
       }
+    return out;
     }
-  };
-
-  // The tagged template tag function name we're looking for.
-  // This is static because it's generally assigned via htm.bind(h),
-  // which could be imported from elsewhere, making tracking impossible.
-  const htmlName = options.tag || 'html';
-
-  function TaggedTemplateExpression(path, state) {
-    fields = new Map();
-
-    const tag = path.node.tag.name;
-    if (htmlName[0]==='/' ? patternStringToRegExp(htmlName).test(tag) : tag === htmlName) {
-      const statics = path.node.quasi.quasis.map(e => e.value.raw);
-      const exprs = path.node.quasi.expressions;
-
-      let tree = treeify(build(statics), exprs);
-
-      // Turn array expression in Array so it can be converted below
-      // to a pragma call expression for fragments.
-      if (t.isArrayExpression(tree)) {
-        tree = tree.elements;
-      }
-
-      if (wrapExpression) {
-        exprs.forEach(expr => {
-          fields.set(expr, path.scope.generateUidIdentifier("field"));
-        });
-      }
-
-      let node = Array.isArray(tree)
-        ? t.callExpression(pragma, [
-            t.arrayExpression(tree.map(root => transform(root, state)))
-          ])
-        : t.isNode(tree) || typeof tree === 'string'
-        ? t.callExpression(pragma, [
-            t.arrayExpression([transform(tree, state)])
-          ])
-        : transform(tree, state);
-
-      if (wrapExpression) {
-        let taggedArgs = Array.from(fields.values());
-        taggedArgs.unshift(path.scope.generateUidIdentifier("statics"));
-
-        node = t.callExpression(dottedIdentifier(`${wrapExpression}.apply`), [
-          t.arrowFunctionExpression(taggedArgs, node),
-          t.arrayExpression([
-            t.arrayExpression(statics.map(str => t.stringLiteral(str))),
-            ...exprs
-          ])
-        ]);
-      }
-
-      path.replaceWith(node);
-      state.set('hasHtm', true);
-    }
-  }
 
   function patternStringToRegExp(str) {
     const parts = str.split('/').slice(1);
@@ -114,38 +61,36 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
     return new RegExp(parts.join('/'), end);
   }
 
-  function dottedIdentifier(keypath) {
-    const path = keypath.split('.');
-    let out;
-    for (let i=0; i<path.length; i++) {
-      const ident = propertyName(path[i]);
-      out = i===0 ? ident : t.memberExpression(out, ident);
+  function propertyName(key) {
+    if (t.isValidIdentifier(key)) {
+      return t.identifier(key);
     }
-    return out;
+    return t.stringLiteral(key);
   }
 
-  function transform(node, state) {
-    node = maybeField(node);
+  function objectProperties(obj) {
+    return Object.keys(obj).map(key => {
+      const values = obj[key].map(valueOrNode =>
+        t.isNode(valueOrNode) ? maybeField(valueOrNode) : t.valueToNode(valueOrNode)
+      );
 
-    if (t.isNode(node)) return node;
-    if (typeof node === 'string') return stringValue(node);
-    if (node === undefined) return t.identifier('undefined');
-
-    const { tag, props, children } = node;
-    const isComponent = typeof tag !== 'string';
-    const newTag = isComponent ? tag : t.stringLiteral(tag);
-    const newProps = spreadNode(props, state);
-    const newChildren = t.arrayExpression((children || [])
-      .map(child => transform(child, state))
-      .map(child => isComponent ? t.arrowFunctionExpression([], child) : child));
-    return createVNode(newTag, newProps, newChildren);
+      let node = values[0];
+      if (values.length > 1) {
+        if (!t.isStringLiteral(node)) {
+          node = t.binaryExpression('+', t.stringLiteral(''), concatFunctionNode(node));
+        }
+        values.slice(1).forEach(value => {
+          node = t.binaryExpression('+', node, concatFunctionNode(value));
+        });
+        if (values.some(isFunctionLike)) {
+          node = t.functionExpression(null, [], t.blockStatement([
+            t.returnStatement(node)
+          ]));
+        }
   }
 
-  function maybeField(node) {
-    if (fields.has(node)) {
-      return fields.get(node);
-    }
-    return node;
+      return t.objectProperty(propertyName(key), node);
+    });
   }
 
   function stringValue(str) {
@@ -159,6 +104,35 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
       ]);
     }
     return t.stringLiteral(str);
+  }
+
+  function createVNode(tag, props, children) {
+    // Never pass children=[[]].
+    if (
+      children.elements.length === 1 &&
+      t.isArrayExpression(children.elements[0]) &&
+      children.elements[0].elements.length === 0
+    ) {
+      children = children.elements[0];
+    }
+
+    if (inlineVNodes) {
+      return t.objectExpression([
+        options.monomorphic && t.objectProperty(propertyName('type'), t.numericLiteral(1)),
+        t.objectProperty(propertyName('tag'), tag),
+        t.objectProperty(propertyName('props'), props),
+        t.objectProperty(propertyName('children'), children),
+        options.monomorphic && t.objectProperty(propertyName('text'), t.nullLiteral())
+      ].filter(Boolean));
+    }
+
+    // Passing `{variableArity:false}` always produces `h(tag, props, children)` - where `children` is always an Array.
+    // Otherwise, the default is `h(tag, props, ...children)`.
+    if (options.variableArity !== false) {
+      children = children.elements;
+    }
+
+    return t.callExpression(pragma, [tag, props].concat(children));
   }
 
   function spreadNode(args, state) {
@@ -196,33 +170,32 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
   }
 
   function propsNode(props) {
-    return t.isNode(props) ?  maybeField(props) : t.objectExpression(objectProperties(props));
+    return t.isNode(props) ? maybeField(props) : t.objectExpression(objectProperties(props));
   }
 
-  function objectProperties(obj) {
-    return Object.keys(obj).map(key => {
-      const values = obj[key].map(valueOrNode =>
-        t.isNode(valueOrNode) ?  maybeField(valueOrNode) : t.valueToNode(valueOrNode)
-      );
+  function transform(node, state) {
+    node = maybeField(node);
 
-      let node = values[0];
-      if (values.length > 1) {
-        if (!t.isStringLiteral(node)) {
-          node = t.binaryExpression('+', t.stringLiteral(''), concatFunctionNode(node));
+    if (t.isNode(node)) return node;
+    if (typeof node === 'string') return stringValue(node);
+    if (node === undefined) return t.identifier('undefined');
+
+    const { tag, props, children } = node;
+    const isComponent = typeof tag !== 'string';
+    const newTag = isComponent ? tag : t.stringLiteral(tag);
+    const newProps = spreadNode(props, state);
+    const newChildren = t.arrayExpression((children || [])
+      .map(child => transform(child, state))
+      .map(child => isComponent ? t.arrowFunctionExpression([], child) : child));
+    return createVNode(newTag, newProps, newChildren);
         }
-        values.slice(1).forEach(value => {
-          node = t.binaryExpression('+', node, concatFunctionNode(value));
-        });
-        if (values.some(isFunctionLike)) {
-          node = t.functionExpression(null, [], t.blockStatement([
-            t.returnStatement(node)
-          ]));
+
+  function maybeField(node) {
+    if (fields.has(node)) {
+      return fields.get(node);
         }
+    return node;
       }
-
-      return t.objectProperty(propertyName(key), node);
-    });
-  }
 
   function isFunctionLike(node) {
     return (
@@ -241,47 +214,66 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
     return node;
   }
 
-  function createVNode(tag, props, children) {
-    // Never pass children=[[]].
-    if (
-      children.elements.length === 1 &&
-      t.isArrayExpression(children.elements[0]) &&
-      children.elements[0].elements.length === 0
-    ) {
-      children = children.elements[0];
-    }
-
-    if (inlineVNodes) {
-      return t.objectExpression([
-        options.monomorphic && t.objectProperty(propertyName('type'), t.numericLiteral(1)),
-        t.objectProperty(propertyName('tag'), tag),
-        t.objectProperty(propertyName('props'), props),
-        t.objectProperty(propertyName('children'), children),
-        options.monomorphic && t.objectProperty(propertyName('text'), t.nullLiteral())
-      ].filter(Boolean));
-    }
-
-    // Passing `{variableArity:false}` always produces `h(tag, props, children)` - where `children` is always an Array.
-    // Otherwise, the default is `h(tag, props, ...children)`.
-    if (options.variableArity !== false) {
-      children = children.elements;
-    }
-
-    return t.callExpression(pragma, [tag, props].concat(children));
-  }
-
-  function propertyName(key) {
-    if (t.isValidIdentifier(key)) {
-      return t.identifier(key);
-    }
-    return t.stringLiteral(key);
-  }
-
+  // The tagged template tag function name we're looking for.
+  // This is static because it's generally assigned via htm.bind(h),
+  // which could be imported from elsewhere, making tracking impossible.
+  const htmlName = options.tag || 'html';
   return {
     name: 'htm',
     visitor: {
-      Program,
-      TaggedTemplateExpression
+      Program: {
+        exit(path, state) {
+          if (state.get('hasHtm') && importDeclaration) {
+            path.unshiftContainer('body', importDeclaration);
+    }
+        },
+      },
+      TaggedTemplateExpression(path, state) {
+        const tag = path.node.tag.name;
+        if (htmlName[0] === '/' ? patternStringToRegExp(htmlName).test(tag) : tag === htmlName) {
+          const statics = path.node.quasi.quasis.map(e => e.value.raw);
+          const exprs = path.node.quasi.expressions;
+
+          let tree = treeify(build(statics), exprs);
+
+          // Turn array expression in Array so it can be converted below
+          // to a pragma call expression for fragments.
+          if (t.isArrayExpression(tree)) {
+            tree = tree.elements;
+    }
+
+          if (wrapExpression) {
+            exprs.forEach(expr => {
+              fields.set(expr, path.scope.generateUidIdentifier("field"));
+            });
+    }
+
+          let node = Array.isArray(tree)
+            ? t.callExpression(pragma, [
+              t.arrayExpression(tree.map(root => transform(root, state)))
+            ])
+            : t.isNode(tree) || typeof tree === 'string'
+              ? t.callExpression(pragma, [
+                t.arrayExpression([transform(tree, state)])
+              ])
+              : transform(tree, state);
+
+          if (wrapExpression) {
+            let taggedArgs = Array.from(fields.values());
+            taggedArgs.unshift(path.scope.generateUidIdentifier("statics"));
+
+            node = t.callExpression(dottedIdentifier(`${wrapExpression}.apply`), [
+              t.arrowFunctionExpression(taggedArgs, node),
+              t.arrayExpression([
+                t.arrayExpression(statics.map(str => t.stringLiteral(str))),
+                ...exprs
+              ])
+            ]);
+  }
+          path.replaceWith(node);
+          state.set('hasHtm', true);
+    }
+  }
     }
   };
 }

--- a/packages/sinuous/babel-plugin-htm/src/index.js
+++ b/packages/sinuous/babel-plugin-htm/src/index.js
@@ -20,7 +20,7 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
   const inlineVNodes = options.monomorphic || pragma === false;
   const importDeclaration = pragmaImport(options.import || false);
   const wrapExpression = options.wrapExpression;
-  const fields = new Map();
+  let fields;
 
   function pragmaImport(imp) {
     if (pragmaString === false || imp === false) {
@@ -229,6 +229,8 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
         },
       },
       TaggedTemplateExpression(path, state) {
+        fields = new Map();
+
         const tag = path.node.tag.name;
         if (htmlName[0] === '/' ? patternStringToRegExp(htmlName).test(tag) : tag === htmlName) {
           const statics = path.node.quasi.quasis.map(e => e.value.raw);

--- a/packages/sinuous/babel-plugin-htm/src/index.js
+++ b/packages/sinuous/babel-plugin-htm/src/index.js
@@ -1,9 +1,9 @@
 import { build, treeify } from '../../htm/src/build.js';
 
 /**
- * @param {Babel} babel
+ * @param {{ types: import('@babel/types') }} babel
  * @param {object} options
- * @param {string} [options.pragma=h]  JSX/hyperscript pragma.
+ * @param {string | false} [options.pragma=h]  JSX/hyperscript pragma.
  * @param {string} [options.tag=html]  The tagged template "tag" function name to process.
  * @param {string | boolean | object} [options.import=false]  Import the tag automatically
  * @param {boolean} [options.monomorphic=false]  Output monomorphic inline objects instead of using String literals.
@@ -51,9 +51,9 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
     for (let i = 0; i < path.length; i++) {
       const ident = propertyName(path[i]);
       out = i === 0 ? ident : t.memberExpression(out, ident);
-      }
-    return out;
     }
+    return out;
+  }
 
   function patternStringToRegExp(str) {
     const parts = str.split('/').slice(1);
@@ -87,7 +87,7 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
             t.returnStatement(node)
           ]));
         }
-  }
+      }
 
       return t.objectProperty(propertyName(key), node);
     });
@@ -188,14 +188,14 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
       .map(child => transform(child, state))
       .map(child => isComponent ? t.arrowFunctionExpression([], child) : child));
     return createVNode(newTag, newProps, newChildren);
-        }
+  }
 
   function maybeField(node) {
     if (fields.has(node)) {
       return fields.get(node);
-        }
+    }
     return node;
-      }
+  }
 
   function isFunctionLike(node) {
     return (
@@ -225,7 +225,7 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
         exit(path, state) {
           if (state.get('hasHtm') && importDeclaration) {
             path.unshiftContainer('body', importDeclaration);
-    }
+          }
         },
       },
       TaggedTemplateExpression(path, state) {
@@ -240,13 +240,13 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
           // to a pragma call expression for fragments.
           if (t.isArrayExpression(tree)) {
             tree = tree.elements;
-    }
+          }
 
           if (wrapExpression) {
             exprs.forEach(expr => {
               fields.set(expr, path.scope.generateUidIdentifier("field"));
             });
-    }
+          }
 
           let node = Array.isArray(tree)
             ? t.callExpression(pragma, [
@@ -269,11 +269,11 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
                 ...exprs
               ])
             ]);
-  }
+          }
           path.replaceWith(node);
           state.set('hasHtm', true);
-    }
-  }
+        }
+      }
     }
   };
 }


### PR DESCRIPTION
For anyone poking around the code of HTM in Sinuous, they're told it's a fork and not a direct import of HTM, but diffing the developit version with Sinuous doesn't read well. It's hard to tell what's changed because the code is all in a different order and creates large blocks in the diff.

Also the package.json says 2.1.0 but if you diff developit's 2.1.0 it's wrong. The one in Sinuous looks like it's based off 3.0.0

**Before:**

![image](https://user-images.githubusercontent.com/44614862/82527113-7b4ead80-9aea-11ea-8561-f5307cd448f5.png)

**After:**

![image](https://user-images.githubusercontent.com/44614862/82526167-2873f680-9ae8-11ea-8111-7e9534b671a4.png)
