### PR TITLE
Improve typings in observable, computed, and map

### DIFF
--- a/packages/sinuous/map/src/index.d.ts
+++ b/packages/sinuous/map/src/index.d.ts
@@ -1,16 +1,7 @@
 import { Observable } from '../../observable/src';
 
-type Item =
-  | string
-  | object;
-type Items = Item[];
-
-type ItemsCreator = (() => Items) | Observable<Items>;
-
-type NodeCreator = (item: Item, i: number, items: Items) => Node;
-
-export function map(
-  items: ItemsCreator,
-  expr: NodeCreator,
+export function map<T>(
+  items: ((...args: unknown[]) => T[]) | Observable<T[]>,
+  expr: (item: T, i: number, items: T[]) => Node,
   cleaning?: boolean
 ): DocumentFragment;

--- a/packages/sinuous/observable/src/index.d.ts
+++ b/packages/sinuous/observable/src/index.d.ts
@@ -1,22 +1,11 @@
-export interface ObservableCreator<T> {
-  (value: T): Observable<T>;
-}
 export interface Observable<T> {
   (): T;
   (nextValue: T): T;
 }
-export const observable: ObservableCreator<any>;
-export const o: ObservableCreator<any>;
-
-export interface Computed<T> {
-  (): T;
-}
-export interface ComputedCreator<T> {
-  (observer: (v: T) => T, seed: T): Computed<T>;
-  (observer: () => T): Computed<T>;
-}
-export const computed: ComputedCreator<any>;
-export const S: ComputedCreator<any>;
+export function observable<T>(value: T): Observable<T>;
+export function o<T>(value: T): Observable<T>;
+export function computed<T extends () => unknown>(observer: T): T;
+export function S<T extends () => unknown>(observer: T): T;
 
 export function subscribe<T>(observer: () => T): () => void;
 export function unsubscribe<T>(observer: () => T): void;
@@ -24,6 +13,4 @@ export function isListening(): boolean;
 export function root<T>(fn: () => T): T;
 export function sample<T>(fn: () => T): T;
 export function transaction<T>(fn: () => T): T;
-
-type CleanupFn = () => any;
-export function cleanup(fn: CleanupFn): CleanupFn;
+export function cleanup<T extends () => unknown>(fn: T): T;

--- a/packages/sinuous/src/index.d.ts
+++ b/packages/sinuous/src/index.d.ts
@@ -2,7 +2,7 @@ export = sinuous;
 export as namespace sinuous;
 
 import { JSXInternal } from './jsx';
-import { Observable, ObservableCreator, subscribe, cleanup, root, sample } from '../observable/src';
+import { Observable, subscribe, cleanup, root, sample } from '../observable/src';
 
 declare namespace sinuous {
   export import JSX = JSXInternal;
@@ -28,8 +28,8 @@ declare namespace sinuous {
     (...children: ElementChildren[]): any
   }
 
-  const observable: ObservableCreator<any>;
-  const o: ObservableCreator<any>;
+  function observable<T>(value: T): Observable<T>;
+  function o<T>(value: T): Observable<T>;
 
   const html: (strings: TemplateStringsArray, ...values: any[]) => HTMLElement | DocumentFragment;
   const svg: (strings: TemplateStringsArray, ...values: any[]) => SVGElement | DocumentFragment;
@@ -101,8 +101,12 @@ declare namespace sinuous {
    * Sinuous internal API.
    */
   interface Api extends Options {
-    insert<T>(el: Node, value: T, marker?: Node, current?: T, startNode?: Node): T;
+    h: typeof h;
+    hs: typeof hs;
+    insert<T>(el: Node, value: T, endMark?: Node, current?: T, startNode?: Node): T;
     property(el: Node, value: any, name: string, isAttr?: boolean, isCss?: boolean): void;
+    add(parent: Node, value: Node | string, endMark?: Node): Node;
+    rm(parent: Node, startNode: Node, endMark: Node): void;
   }
 
   const api: Api;


### PR DESCRIPTION
I'm very into Typescript (and I'll send you a PR of a Typescript+JSX+Snowpack Sinuous example soon!). I noticed it's hard to develop in TS with Sinuous. I'll show some examples:

**Before**

Here's `observable` and `computed` that both resolve to "any", so typing isn't useful:

![image](https://user-images.githubusercontent.com/44614862/82528110-e9946f80-9aec-11ea-822a-d0f27350eae7.png)

This `computed` example is from your readme

![image](https://user-images.githubusercontent.com/44614862/82528160-003ac680-9aed-11ea-9343-7afed7c13641.png)

Here's `map` showing an error about "Item":

![image](https://user-images.githubusercontent.com/44614862/82527626-bef5e700-9aeb-11ea-9f89-61da24af48bc.png)

**After**

The new typings infer the type given to the functions observable/computed/map which fixes these issues.

Observables won't default to `Observable<any>`:

![image](https://user-images.githubusercontent.com/44614862/82528554-e057d280-9aed-11ea-9623-7e3a734bfafc.png)

Computed functions infer their return type too, so errors like this can be caught (where `messages` is an `Observable<string[]>`:

![image](https://user-images.githubusercontent.com/44614862/82528636-15642500-9aee-11ea-9919-fd3952b95f45.png)
 
Also `map` doesn't use "Item" anymore, and instead infers types correctly from the function or list provided:

![image](https://user-images.githubusercontent.com/44614862/82528725-46dcf080-9aee-11ea-91ff-d1385d44aeb2.png)

The only hiccup is people will see `const list = observable([])` resolve as `never[]` if they have strict null checking on (as I do). See https://github.com/microsoft/TypeScript/pull/8944. To fix this, as shown in the map picture just above, use `observable([] as string[])`.