### PR TITLE
Typescript definition changes and explaining Sinuous internals

### DIFF
--- a/packages/sinuous/h/src/add.js
+++ b/packages/sinuous/h/src/add.js
@@ -10,7 +10,8 @@ const castNode = (value) => {
   }
   // Note that a DocumentFragment is an instance of Node
   if (!(value instanceof Node)) {
-    // Passing an empty array creates a DocumentFragment.
+    // Passing an empty array creates a DocumentFragment
+    // Note this means api.add is not purely a subcall of api.h; it can nest
     return api.h(EMPTY_ARR, value);
   }
   return value;

--- a/packages/sinuous/h/src/api.js
+++ b/packages/sinuous/h/src/api.js
@@ -2,7 +2,7 @@
  * Internal API.
  * Consumer must provide an observable at api.subscribe<T>(observer: () => T).
  *
- * @typedef {0 | 1} hSVG Determines if `h` will build HTML or SVG elements
+ * @typedef {boolean} hSVG Determines if `h` will build HTML or SVG elements
  * @type {{
  * h:         import('./h.js').hTag
  * s:         hSVG

--- a/packages/sinuous/h/src/h.js
+++ b/packages/sinuous/h/src/h.js
@@ -7,7 +7,7 @@ import { api } from './api.js';
  * @typedef {(tag: string? | [], props: object?, ...children: Node | *) => DOM} hTag
  * @type {hTag}
  */
-// eslint-disable-next-line fp/no-rest-parameters
+
 export const h = (...args) => {
   let el;
   const item = (/** @type {*} */ arg) => {

--- a/packages/sinuous/h/src/index.d.ts
+++ b/packages/sinuous/h/src/index.d.ts
@@ -19,8 +19,9 @@ declare namespace _h {
         Record<string, unknown>
       | null,
     ...children: ElementChildren[]
-  ): HTMLElement | SVGElement;
+  ): HTMLElement | SVGElement | DocumentFragment;
   function h(
+    tag: ElementChildren[] | [],
     ...children: ElementChildren[]
   ): DocumentFragment;
   namespace h {

--- a/packages/sinuous/h/src/index.d.ts
+++ b/packages/sinuous/h/src/index.d.ts
@@ -37,7 +37,7 @@ export interface HyperscriptApi {
   h: typeof _h.h;
 
   // Internal API
-  insert<T>(el: Node, value: T, endMark?: Node, current?: T | Frag, startNode?: Node): T;
+  insert<T>(el: Node, value: T, endMark?: Node, current?: T | Frag, startNode?: Node): T | Frag;
   property(el: Node, value: unknown, name: string, isAttr?: boolean, isCss?: boolean): void;
   add(parent: Node, value: Value | Value[], endMark?: Node): Node | Frag;
   rm(parent: Node, startNode: Node, endMark: Node): void;

--- a/packages/sinuous/h/src/insert.js
+++ b/packages/sinuous/h/src/insert.js
@@ -2,7 +2,8 @@ import { api } from './api.js';
 
 /**
  * @typedef {import('./add.js').Frag} Frag
- * @typedef {(el: Node, value: *, endMark: Node?, current: (Node | Frag)?, startNode: Node?) => Node} hInsert
+ * @typedef {(el: Node, value: *, endMark: Node?, current: (Node | Frag)?,
+ * startNode: Node?) => Node | Frag } hInsert
  * @type {hInsert}
  */
 export const insert = (el, value, endMark, current, startNode) => {
@@ -64,5 +65,5 @@ export const insert = (el, value, endMark, current, startNode) => {
     }
   }
 
-  return /** @type {Node} */ (current);
+  return current;
 };

--- a/packages/sinuous/src/index.d.ts
+++ b/packages/sinuous/src/index.d.ts
@@ -39,7 +39,7 @@ declare namespace sinuous {
         Record<string, unknown>
       | null,
     ...children: ElementChildren[]
-  ): HTMLElement;
+  ): HTMLElement | DocumentFragment;
   function h(
     tag: ElementChildren[] | [],
     ...children: ElementChildren[]
@@ -63,7 +63,7 @@ declare namespace sinuous {
         Record<string, unknown>
       | null,
     ...children: ElementChildren[]
-  ): SVGElement;
+  ): SVGElement | DocumentFragment;
   function hs(
     tag: ElementChildren[] | [],
     ...children: ElementChildren[]

--- a/packages/sinuous/src/index.d.ts
+++ b/packages/sinuous/src/index.d.ts
@@ -41,6 +41,7 @@ declare namespace sinuous {
     ...children: ElementChildren[]
   ): HTMLElement;
   function h(
+    tag: ElementChildren[] | [],
     ...children: ElementChildren[]
   ): DocumentFragment;
   namespace h {
@@ -64,6 +65,7 @@ declare namespace sinuous {
     ...children: ElementChildren[]
   ): SVGElement;
   function hs(
+    tag: ElementChildren[] | [],
     ...children: ElementChildren[]
   ): DocumentFragment;
   namespace hs {
@@ -73,7 +75,6 @@ declare namespace sinuous {
   /** Sinuous API */
   interface SinuousApi extends HyperscriptApi {
     // Hyperscript
-    h: typeof h;
     hs: <T extends () => unknown>(closure: T) => ReturnType<T>;
 
     // Observable

--- a/packages/sinuous/src/index.d.ts
+++ b/packages/sinuous/src/index.d.ts
@@ -74,7 +74,7 @@ declare namespace sinuous {
   interface SinuousApi extends HyperscriptApi {
     // Hyperscript
     h: typeof h;
-    hs: typeof hs;
+    hs: <T extends () => unknown>(closure: T) => ReturnType<T>;
 
     // Observable
     subscribe: typeof _o.subscribe;

--- a/packages/sinuous/src/index.js
+++ b/packages/sinuous/src/index.js
@@ -1,7 +1,7 @@
 /*
-* Sinuous by Wesley Luyten (@luwes).
-* Really ties all the packages together.
-*/
+ * Sinuous by Wesley Luyten (@luwes).
+ * Really ties all the packages together.
+ */
 import {
   o,
   observable,


### PR DESCRIPTION
I've been trying to understand how Sinuous works a bit better since I'm writing taping into the API calls, mostly `api.add`, to have tracing of its execution. Running into issues where it's hard to understand how data flows through. Some of the JSDoc types aren't as details as they could be, for instance, I believe `api.add(parent, value, endMark)` could be given a DocumentFragment or an Array as a `value` but the JSDoc just says "Node" (I understand that a fragment is an instance of Node but it's not super clear).

Update: I actually finished the project that prompted all these commits/PRs into Sinuous. I was trying to add onAttach/onDetach hooks without using MutationObserver and needed to better understand how api.add/insert/h worked but I figured it out in the end. Added some comments in this PR for anyone who comes after me...