### PR TITLE
Permit observables as values in style objects in Typescript + JSX

### DIFF
--- a/packages/sinuous/jsx.d.ts
+++ b/packages/sinuous/jsx.d.ts
@@ -1,7 +1,8 @@
 import { Observable } from './observable/src';
 
 export namespace JSXInternal {
-  type AllowObservable<Props> = { [K in keyof Props]: Props[K] | Observable<Props[K]> }
+  type OrObservable<T> = T | Observable<T>
+  type AllowObservable<Props> = { [K in keyof Props]: OrObservable<Props[K]> }
 
   interface Element extends HTMLElement { }
 
@@ -695,7 +696,9 @@ export namespace JSXInternal {
     srcSet?: string;
     start?: number;
     step?: number | string;
-    style?: string | { [key: string]: string | number };
+    style?:
+      | string
+      | { [key: string]: OrObservable<string | number> };
     summary?: string;
     tabIndex?: number;
     target?: string;


### PR DESCRIPTION
This fixes a mismatch between the currently exposed JSX typings and the API for style values. For example,

```tsx
function Blink() {
  const hidden = observable(false);
  setInterval(() => hidden(!hidden()), 1000);

  return (
    <span style={{
      visibility: () => hidden() ? 'visible' : 'hidden'
    }}>
      blink tag?
    </span>
  );
}
```

is now permitted, where it wasn't before.

If there are other values which allow this nested-observable behavior, then those might need to be adjusted as well.