### PR TITLE
Remove seemingly unneeded code - 0.27.11-beta.0

### DIFF
--- a/packages/sinuous/observable/src/observable.js
+++ b/packages/sinuous/observable/src/observable.js
@@ -154,32 +154,11 @@ function computed(observer, value) {
       tracking._children.push(update);
     }
 
-    const prevChildren = update._children;
-
     _unsubscribe(update);
     update._fresh = true;
     tracking = update;
     value = observer(value);
 
-    // If any children computations were removed mark them as fresh.
-    // Check the diff of the children list between pre and post update.
-    prevChildren.forEach(u => {
-      if (update._children.indexOf(u) === -1) {
-        u._fresh = true;
-      }
-    });
-
-    // If any children were marked as fresh remove them from the run lists.
-    let curr;
-    const queue = [].concat(update.children);
-    while (curr = queue.pop()) {
-      if (curr._fresh) {
-        curr._observables.forEach(o => {
-          if (o._runObservers) o._runObservers.delete(curr);
-        });
-      }
-      curr.children.forEach(u => queue.push(u));
-    }
     tracking = prevTracking;
     return value;
   }


### PR DESCRIPTION
Related to #142

Since the below block is added here fixing a memory leak it looks like the logic to pick off fresh children is not needed anymore.

https://github.com/luwes/sinuous/blob/e351892dd46b439354c6d4c41eb7f9ed6b709b11/packages/sinuous/observable/src/observable.js#L250-L252

Still kinda puzzled that it wouldn't result in any bugs. e.g 
https://github.com/luwes/sinuous/issues/20#issuecomment-526250502

