### PR TITLE
Add exports for Node ESM resolution

### DIFF
--- a/packages/sinuous/package.json
+++ b/packages/sinuous/package.json
@@ -4,6 +4,49 @@
   "description": "🧬 Small, fast, reactive render engine",
   "module": "module/sinuous.js",
   "main": "dist/sinuous.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./module/sinuous.js",
+      "require": "./dist/sinuous.js"
+    },
+    "./all": {
+      "import": "./module/all.js",
+      "require": "./dist/all.js"
+    },
+    "./data": {
+      "import": "./module/data.js",
+      "require": "./dist/data.js"
+    },
+    "./h": {
+      "import": "./module/h.js",
+      "require": "./dist/h.js"
+    },
+    "./htm": {
+      "import": "./module/htm.js",
+      "require": "./dist/htm.js"
+    },
+    "./hydrate": {
+      "import": "./module/hydrate.js",
+      "require": "./dist/hydrate.js"
+    },
+    "./map": {
+      "import": "./module/map.js",
+      "require": "./dist/map.js"
+    },
+    "./observable": {
+      "import": "./module/observable.js",
+      "require": "./dist/observable.js"
+    },
+    "./render": {
+      "import": "./module/render.js",
+      "require": "./dist/render.js"
+    },
+    "./template": {
+      "import": "./module/template.js",
+      "require": "./dist/template.js"
+    }
+  },
   "types": "src/index.d.ts",
   "files": [
     "module",


### PR DESCRIPTION
Some bundlers can't resolve the correct ESM imports for `sinuous` due to the lack of a `"type": "module"` definition along with `"exports"` definitions for each package. Specifically, this will allow `sinuous` to work with [`vitest`](https://github.com/vitest-dev/vitest).

Check out this explanation on [dual packaging](https://github.com/sheremet-va/dual-packaging) for more info.