### PR TITLE
fix: set ES module flag in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "module": "src/index.js",
   "main": "src/index.js",
   "types": "src/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "import": "./src/index.js"


### PR DESCRIPTION
NodeJS requires `"type": "module"` in package.json in order to be considered a valid ES module. This is required for isomorphic apps using sinuous on both server and client.

Fixes #233 